### PR TITLE
Change 'COMPILED-RELEASES' transform to 'COMPILE-RELEASES', and make …

### DIFF
--- a/docs/cli-new-transform-compile-releases.rst
+++ b/docs/cli-new-transform-compile-releases.rst
@@ -1,4 +1,4 @@
-Command line tool - new-transform-compiled-releases option
+Command line tool - new-transform-compile-releases option
 ==========================================================
 
 This command takes an existing source collection that you give it, and creates a new destination collection with a transform that creates compiled releases.
@@ -11,6 +11,6 @@ It will create a new destination collection to hold the compiled releases and re
 
 .. code-block:: shell-session
 
-    python ocdskingfisher-process-cli new-transform-compiled-releases 17
+    python ocdskingfisher-process-cli new-transform-compile-releases 17
 
 After creating it, you should run transform-collection to actually do the work. See :doc:`cli-transform-collection`

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -18,7 +18,7 @@ You can pass the `verbose` flag to all sub commands, to get more output printed 
    cli-list-collections.rst
    cli-local-load.rst
    cli-check-collection.rst
-   cli-new-transform-compiled-releases.rst
+   cli-new-transform-compile-releases.rst
    cli-new-transform-upgrade-1-0-to-1-1.rst
    cli-transform-collection.rst
 

--- a/ocdskingfisherprocess/cli/commands/new_transform_compile_releases.py
+++ b/ocdskingfisherprocess/cli/commands/new_transform_compile_releases.py
@@ -3,8 +3,8 @@ import ocdskingfisherprocess.cli.commands.base
 from ocdskingfisherprocess.transform.compile_releases import CompileReleasesTransform
 
 
-class NewTransformCompiledReleasesCLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
-    command = 'new-transform-compiled-releases'
+class NewTransformCompileReleasesCLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
+    command = 'new-transform-compile-releases'
 
     def configure_subparser(self, subparser):
         self.configure_subparser_for_selecting_existing_collection(subparser)

--- a/ocdskingfisherprocess/transform/compile_releases.py
+++ b/ocdskingfisherprocess/transform/compile_releases.py
@@ -4,7 +4,7 @@ import ocdsmerge
 
 
 class CompileReleasesTransform(BaseTransform):
-    type = 'COMPILED-RELEASES'
+    type = 'compile-releases'
 
     def process(self):
         for ocid in self.get_ocids():

--- a/ocdskingfisherprocess/transform/upgrade_1_0_to_1_1.py
+++ b/ocdskingfisherprocess/transform/upgrade_1_0_to_1_1.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 
 
 class Upgrade10To11Transform(BaseTransform):
-    type = 'UPGRADE-1-0-TO-1-1'
+    type = 'upgrade-1-0-to-1-1'
 
     def process(self):
         for file_model in self.database.get_all_files_in_collection(self.source_collection.database_id):


### PR DESCRIPTION
…all transform names lower case

To make a consistent type of names for transforms.

(Normally we should try and change any existing transforms in the DB at the same time, but this isn't live yet.)

https://github.com/open-contracting/kingfisher-process/issues/24