### PR TITLE
HTTP API Endpoints - check required fields are there and sane, error …

### DIFF
--- a/ocdskingfisherprocess/util.py
+++ b/ocdskingfisherprocess/util.py
@@ -110,6 +110,8 @@ class FileToStore:
 
 
 def parse_string_to_date_time(date_time_string):
+    if not date_time_string:
+        return None
     if " " in date_time_string:
         # The docs define this format
         return datetime.datetime.strptime(date_time_string, "%Y-%m-%d %H:%M:%S")

--- a/ocdskingfisherprocess/web/views_api_v1.py
+++ b/ocdskingfisherprocess/web/views_api_v1.py
@@ -1,0 +1,190 @@
+from flask import request, views
+from ocdskingfisherprocess.config import Config
+from ocdskingfisherprocess.store import Store
+from ocdskingfisherprocess.database import DataBase
+from ocdskingfisherprocess.util import parse_string_to_date_time, parse_string_to_boolean
+import tempfile
+import os
+import json
+
+config = Config()
+config.load_user_config()
+
+
+class RootV1View(views.View):
+
+    def dispatch_request(self):
+        return "OCDS Kingfisher APIs V1"
+
+
+class BaseAPIViewAuthAndCollectionNeeded(views.View):
+
+    def _check_authorization(self, request):
+        api_key = request.headers.get('Authorization', '')[len('ApiKey '):]
+        return api_key and api_key in config.web_api_keys
+
+    def _load_collection_variables(self, request):
+
+        # get source, test
+        self.collection_source = request.form.get('collection_source')
+
+        if not self.collection_source:
+            return False
+
+        # get data_version, test
+        self.collection_data_version = parse_string_to_date_time(request.form.get('collection_data_version'))
+
+        if not self.collection_data_version:
+            return False
+
+        # get sample (No test because if it's not there it is read as False and that's fine)
+        self.collection_sample = parse_string_to_boolean(request.form.get('collection_sample', False))
+
+        # all passed so ...
+        return True
+
+
+class SubmitEndCollectionStoreView(BaseAPIViewAuthAndCollectionNeeded):
+    methods = ['POST']
+
+    def dispatch_request(self):
+        if not self._check_authorization(request):
+            return "ACCESS DENIED", 401
+
+        if not self._load_collection_variables(request):
+            return "COLLECTION FIELDS NOT SPECIFIED", 400
+
+        # TODO check all required fields are there!
+
+        database = DataBase(config=config)
+        store = Store(config=config, database=database)
+
+        store.load_collection(
+            self.collection_source,
+            self.collection_data_version,
+            self.collection_sample,
+        )
+
+        if store.is_collection_store_ended():
+            return "OCDS Kingfisher APIs V1 Submit - Already Done!"
+        else:
+            store.end_collection_store()
+            return "OCDS Kingfisher APIs V1 Submit"
+
+
+class SubmitFileView(BaseAPIViewAuthAndCollectionNeeded):
+    methods = ['POST']
+
+    def dispatch_request(self):
+        if not self._check_authorization(request):
+            return "ACCESS DENIED", 401
+
+        if not self._load_collection_variables(request):
+            return "COLLECTION FIELDS NOT SPECIFIED", 400
+
+        # TODO check all required fields are there!
+
+        database = DataBase(config=config)
+        store = Store(config=config, database=database)
+
+        store.load_collection(
+            self.collection_source,
+            self.collection_data_version,
+            self.collection_sample,
+        )
+
+        file_filename = request.form.get('file_name')
+        file_url = request.form.get('url')
+        file_data_type = request.form.get('data_type')
+        file_encoding = request.form.get('encoding', 'utf-8')
+
+        if 'file' in request.files:
+
+            (tmp_file, tmp_filename) = tempfile.mkstemp(prefix="ocdskf-")
+            os.close(tmp_file)
+
+            request.files['file'].save(tmp_filename)
+
+            store.store_file_from_local(file_filename, file_url, file_data_type, file_encoding, tmp_filename)
+
+            os.remove(tmp_filename)
+
+        elif 'local_file_name' in request.form:
+
+            store.store_file_from_local(file_filename, file_url, file_data_type, file_encoding, request.form.get('local_file_name'))
+
+        else:
+
+            raise Exception('Did not send file data')
+
+        return "OCDS Kingfisher APIs V1 Submit"
+
+
+class SubmitItemView(BaseAPIViewAuthAndCollectionNeeded):
+    methods = ['POST']
+
+    def dispatch_request(self):
+        if not self._check_authorization(request):
+            return "ACCESS DENIED", 401
+
+        if not self._load_collection_variables(request):
+            return "COLLECTION FIELDS NOT SPECIFIED", 400
+
+        # TODO check all required fields are there!
+
+        database = DataBase(config=config)
+        store = Store(config=config, database=database)
+
+        store.load_collection(
+            self.collection_source,
+            self.collection_data_version,
+            self.collection_sample,
+        )
+
+        file_filename = request.form.get('file_name')
+        file_url = request.form.get('url')
+        file_data_type = request.form.get('data_type')
+        item_number = int(request.form.get('number'))
+
+        data = json.loads(request.form.get('data'))
+
+        store.store_file_item(
+            file_filename,
+            file_url,
+            file_data_type,
+            data,
+            item_number,
+        )
+
+        return "OCDS Kingfisher APIs V1 Submit"
+
+
+class SubmitFileErrorsView(BaseAPIViewAuthAndCollectionNeeded):
+    methods = ['POST']
+
+    def dispatch_request(self):
+        if not self._check_authorization(request):
+            return "ACCESS DENIED", 401
+
+        if not self._load_collection_variables(request):
+            return "COLLECTION FIELDS NOT SPECIFIED", 400
+
+        # TODO check all required fields are there!
+
+        database = DataBase(config=config)
+        store = Store(config=config, database=database)
+
+        store.load_collection(
+            self.collection_source,
+            self.collection_data_version,
+            self.collection_sample,
+        )
+
+        file_filename = request.form.get('file_name')
+        file_errors_raw = request.form.get('errors')
+        file_errors = json.loads(file_errors_raw)
+        file_url = request.form.get('url')
+
+        store.store_file_errors(file_filename, file_url, file_errors)
+
+        return "OCDS Kingfisher APIs V1 Submit"

--- a/tests/test_web_api_v1.py
+++ b/tests/test_web_api_v1.py
@@ -249,3 +249,16 @@ class TestWebAPIV1(BaseWebTest):
         assert files[0].errors[0] == 'The error was ... because reasons.'
         assert files[0].store_start_at == None # noqa
         assert files[0].store_end_at == None # noqa
+
+    def test_api_v1_submit_item_nothing(self):
+        self.setup_main_database()
+
+        # Call
+        data = {
+        }
+
+        result = self.flaskclient.post('/api/v1/submit/item/',
+                                       data=data,
+                                       headers={'Authorization': 'ApiKey ' + self.config.web_api_keys[0]})
+
+        assert result.status_code == 400


### PR DESCRIPTION
…with HTTP code if not

Start with collection fields - even this catches the case of someone submitting no data by mistake.

Start breaking /app/ and /api/ views into seperate files to avoid one huge file later!

Change to classes for ease of code reuse, and to allow more flexibility later.

https://github.com/open-contracting/kingfisher-process/issues/47