### PR TITLE
Storing when transforms end and run needs improving

### DIFF
--- a/docs/cli-new-transform-compile-releases.rst
+++ b/docs/cli-new-transform-compile-releases.rst
@@ -3,7 +3,7 @@ Command line tool - new-transform-compile-releases option
 
 This command takes an existing source collection that you give it, and creates a new destination collection with a transform that creates compiled releases.
 
-The compile releases transform can only work when it has all the data, therefore the source collection must be completely saved before you start this transform.
+The compile releases transform can only work when it has all the data! You can create the transform at any time, but the source collection must be completely stored before any work will be done on the transform.
 
 Pass the ID of the source collection. Use :doc:`cli-list-collections` to look up the ID you want.
 

--- a/ocdskingfisherprocess/database.py
+++ b/ocdskingfisherprocess/database.py
@@ -418,7 +418,7 @@ class DataBase:
         with self.get_engine().begin() as connection:
             connection.execute(
                 self.collection_table.update()
-                    .where(self.collection_table.c.id == collection_id)
+                    .where((self.collection_table.c.id == collection_id) & (self.collection_table.c.store_end_at == None)) # noqa
                     .values(store_end_at=datetime.datetime.utcnow())
             )
             # TODO Mark store_end_at on all files not yet marked

--- a/ocdskingfisherprocess/transform/compile_releases.py
+++ b/ocdskingfisherprocess/transform/compile_releases.py
@@ -8,12 +8,24 @@ class CompileReleasesTransform(BaseTransform):
     type = 'compile-releases'
 
     def process(self):
+        # This transform can only run when the source collection is fully stored!
+        if not self.source_collection.store_end_at:
+            return
+
+        # Have we already marked this transform as finished?
+        if self.destination_collection.store_end_at:
+            return
+
+        # Do the work ...
         for ocid in self.get_ocids():
             if not self.has_ocid_been_transformed(ocid):
                 self.process_ocid(ocid)
             # Early return?
             if self.run_until_timestamp and self.run_until_timestamp < datetime.datetime.utcnow().timestamp():
                 return
+
+        # Mark Transform as finished
+        self.database.mark_collection_store_done(self.destination_collection.database_id)
 
     def get_ocids(self):
         ocids = []

--- a/ocdskingfisherprocess/transform/upgrade_1_0_to_1_1.py
+++ b/ocdskingfisherprocess/transform/upgrade_1_0_to_1_1.py
@@ -8,11 +8,20 @@ class Upgrade10To11Transform(BaseTransform):
     type = 'upgrade-1-0-to-1-1'
 
     def process(self):
+        # Have we already marked this transform as finished?
+        if self.destination_collection.store_end_at:
+            return
+
+        # Do the work ...
         for file_model in self.database.get_all_files_in_collection(self.source_collection.database_id):
             self.process_file(file_model)
             # Early return?
             if self.run_until_timestamp and self.run_until_timestamp < datetime.datetime.utcnow().timestamp():
                 return
+
+        # If the source collection is finished, then we can mark the transform as finished
+        if self.source_collection.store_end_at:
+            self.database.mark_collection_store_done(self.destination_collection.database_id)
 
     def process_file(self, file_model):
         for file_item_model in self.database.get_all_files_items_in_file(file_model):

--- a/tests/test_transform_upgrade_1_0_to_1_1.py
+++ b/tests/test_transform_upgrade_1_0_to_1_1.py
@@ -76,6 +76,21 @@ class TestTransformUpgrade10To11(BaseTest):
             result = connection.execute(s)
             assert 0 == result.rowcount
 
+        # destination collection will not be closed (because source is still open!)
+        destination_collection = self.database.get_collection(destination_collection_id)
+        assert destination_collection.store_end_at == None # noqa
+
+        # Mark source collection as finished
+        self.database.mark_collection_store_done(source_collection_id)
+
+        # transform again! This should be fine
+        transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
+        transform.process()
+
+        # destination collection should be closed
+        destination_collection = self.database.get_collection(destination_collection_id)
+        assert destination_collection.store_end_at != None # noqa
+
     def test_release_1(self):
         self.setup_main_database()
 
@@ -143,3 +158,18 @@ class TestTransformUpgrade10To11(BaseTest):
             s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_release_table])
             result = connection.execute(s)
             assert 1 == result.rowcount
+
+        # destination collection will not be closed (because source is still open!)
+        destination_collection = self.database.get_collection(destination_collection_id)
+        assert destination_collection.store_end_at == None # noqa
+
+        # Mark source collection as finished
+        self.database.mark_collection_store_done(source_collection_id)
+
+        # transform!
+        transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
+        transform.process()
+
+        # destination collection should be closed
+        destination_collection = self.database.get_collection(destination_collection_id)
+        assert destination_collection.store_end_at != None # noqa


### PR DESCRIPTION
https://github.com/open-contracting/kingfisher-process/issues/89

Upgrade to 1.1

    * Bug fix; don't mark destination collection transform ended till source one has ended too! More data could arrive in the source!

compile releases

    * Let user create this at any time, but don't let it run until source collection has ended!