### PR TITLE
    Move Transform contstants to __init__

### DIFF
--- a/ocdskingfisherprocess/cli/commands/new_transform_compile_releases.py
+++ b/ocdskingfisherprocess/cli/commands/new_transform_compile_releases.py
@@ -1,6 +1,6 @@
 import ocdskingfisherprocess.database
 import ocdskingfisherprocess.cli.commands.base
-from ocdskingfisherprocess.transform.compile_releases import CompileReleasesTransform
+from ocdskingfisherprocess.transform import TRANSFORM_TYPE_COMPILE_RELEASES
 
 
 class NewTransformCompileReleasesCLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
@@ -17,7 +17,7 @@ class NewTransformCompileReleasesCLICommand(ocdskingfisherprocess.cli.commands.b
             self.collection.data_version,
             self.collection.sample,
             transform_from_collection_id=self.collection.database_id,
-            transform_type=CompileReleasesTransform.type)
+            transform_type=TRANSFORM_TYPE_COMPILE_RELEASES)
         if id:
             if not args.quiet:
                 print("Already exists! The ID is {}".format(id))
@@ -27,7 +27,7 @@ class NewTransformCompileReleasesCLICommand(ocdskingfisherprocess.cli.commands.b
                                                        self.collection.data_version,
                                                        self.collection.sample,
                                                        transform_from_collection_id=self.collection.database_id,
-                                                       transform_type=CompileReleasesTransform.type)
+                                                       transform_type=TRANSFORM_TYPE_COMPILE_RELEASES)
 
         if not args.quiet:
             print("Created! The ID is {}".format(id))

--- a/ocdskingfisherprocess/cli/commands/new_transform_upgrade_1_0_to_1_1.py
+++ b/ocdskingfisherprocess/cli/commands/new_transform_upgrade_1_0_to_1_1.py
@@ -1,6 +1,6 @@
 import ocdskingfisherprocess.database
 import ocdskingfisherprocess.cli.commands.base
-from ocdskingfisherprocess.transform.upgrade_1_0_to_1_1 import Upgrade10To11Transform
+from ocdskingfisherprocess.transform import TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1
 
 
 class NewTransformUpgrade10To11CLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
@@ -17,7 +17,7 @@ class NewTransformUpgrade10To11CLICommand(ocdskingfisherprocess.cli.commands.bas
             self.collection.data_version,
             self.collection.sample,
             transform_from_collection_id=self.collection.database_id,
-            transform_type=Upgrade10To11Transform.type)
+            transform_type=TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
         if id:
             if not args.quiet:
                 print("Already exists! The ID is {}".format(id))
@@ -27,7 +27,7 @@ class NewTransformUpgrade10To11CLICommand(ocdskingfisherprocess.cli.commands.bas
                                                        self.collection.data_version,
                                                        self.collection.sample,
                                                        transform_from_collection_id=self.collection.database_id,
-                                                       transform_type=Upgrade10To11Transform.type)
+                                                       transform_type=TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
 
         if not args.quiet:
             print("Created! The ID is {}".format(id))

--- a/ocdskingfisherprocess/transform/__init__.py
+++ b/ocdskingfisherprocess/transform/__init__.py
@@ -1,0 +1,4 @@
+
+# These constants list the values that are written to the database, and should not be changed without changing contents in the database.
+TRANSFORM_TYPE_COMPILE_RELEASES = 'compile-releases'
+TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1 = 'upgrade-1-0-to-1-1'

--- a/ocdskingfisherprocess/transform/compile_releases.py
+++ b/ocdskingfisherprocess/transform/compile_releases.py
@@ -5,7 +5,6 @@ import datetime
 
 
 class CompileReleasesTransform(BaseTransform):
-    type = 'compile-releases'
 
     def process(self):
         # This transform can only run when the source collection is fully stored!

--- a/ocdskingfisherprocess/transform/upgrade_1_0_to_1_1.py
+++ b/ocdskingfisherprocess/transform/upgrade_1_0_to_1_1.py
@@ -5,7 +5,6 @@ import datetime
 
 
 class Upgrade10To11Transform(BaseTransform):
-    type = 'upgrade-1-0-to-1-1'
 
     def process(self):
         # Have we already marked this transform as finished?

--- a/ocdskingfisherprocess/transform/util.py
+++ b/ocdskingfisherprocess/transform/util.py
@@ -1,11 +1,12 @@
 from ocdskingfisherprocess.transform.compile_releases import CompileReleasesTransform
 from ocdskingfisherprocess.transform.upgrade_1_0_to_1_1 import Upgrade10To11Transform
+from ocdskingfisherprocess.transform import TRANSFORM_TYPE_COMPILE_RELEASES, TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1
 
 
 def get_transform_instance(type, config, database, destination_collection, run_until_timestamp=None):
-    if type == CompileReleasesTransform.type:
+    if type == TRANSFORM_TYPE_COMPILE_RELEASES:
         return CompileReleasesTransform(config, database, destination_collection, run_until_timestamp=run_until_timestamp)
-    elif type == Upgrade10To11Transform.type:
+    elif type == TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1:
         return Upgrade10To11Transform(config, database, destination_collection, run_until_timestamp=run_until_timestamp)
     else:
         raise Exception("That transform type is not known")

--- a/tests/test_transform_compile_releases.py
+++ b/tests/test_transform_compile_releases.py
@@ -3,6 +3,8 @@ import datetime
 import sqlalchemy as sa
 from ocdskingfisherprocess.store import Store
 from ocdskingfisherprocess.transform.compile_releases import CompileReleasesTransform
+from ocdskingfisherprocess.transform import TRANSFORM_TYPE_COMPILE_RELEASES
+
 import os
 
 
@@ -29,7 +31,7 @@ class TestTransformCompileReleases(BaseTest):
             source_collection.data_version,
             source_collection.sample,
             transform_from_collection_id=source_collection_id,
-            transform_type=CompileReleasesTransform.type)
+            transform_type=TRANSFORM_TYPE_COMPILE_RELEASES)
         destination_collection = self.database.get_collection(destination_collection_id)
 
         # transform! Nothing should happen because source is not finished

--- a/tests/test_transform_upgrade_1_0_to_1_1.py
+++ b/tests/test_transform_upgrade_1_0_to_1_1.py
@@ -3,6 +3,7 @@ import datetime
 import sqlalchemy as sa
 from ocdskingfisherprocess.store import Store
 from ocdskingfisherprocess.transform.upgrade_1_0_to_1_1 import Upgrade10To11Transform
+from ocdskingfisherprocess.transform import TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1
 import os
 
 
@@ -29,7 +30,7 @@ class TestTransformUpgrade10To11(BaseTest):
             source_collection.data_version,
             source_collection.sample,
             transform_from_collection_id=source_collection_id,
-            transform_type=Upgrade10To11Transform.type)
+            transform_type=TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
         destination_collection = self.database.get_collection(destination_collection_id)
 
         # transform!
@@ -112,7 +113,7 @@ class TestTransformUpgrade10To11(BaseTest):
             source_collection.data_version,
             source_collection.sample,
             transform_from_collection_id=source_collection_id,
-            transform_type=Upgrade10To11Transform.type)
+            transform_type=TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
         destination_collection = self.database.get_collection(destination_collection_id)
 
         # transform!


### PR DESCRIPTION
    This will avoid a problem with circular imports in later work