### PR TITLE
index collection_file_item_id in release/record table

### DIFF
--- a/ocdskingfisherprocess/database.py
+++ b/ocdskingfisherprocess/database.py
@@ -118,6 +118,8 @@ class DataBase:
                                       sa.Column('package_data_id', sa.Integer,
                                                 sa.ForeignKey("package_data.id", name="fk_release_package_data_id"),
                                                 nullable=False),
+                                      sa.Index('release_collection_file_item_id_idx', 'collection_file_item_id'),
+                                      sa.Index('release_ocid_idx', 'ocid')
                                       )
 
         self.record_table = sa.Table('record', self.metadata,
@@ -131,6 +133,8 @@ class DataBase:
                                      sa.Column('package_data_id', sa.Integer,
                                                sa.ForeignKey("package_data.id", name="fk_record_package_data_id"),
                                                nullable=False),
+                                     sa.Index('record_collection_file_item_id_idx', 'collection_file_item_id'),
+                                     sa.Index('record_ocid_idx', 'ocid')
                                      )
 
         self.compiled_release_table = sa.Table('compiled_release', self.metadata,
@@ -143,6 +147,7 @@ class DataBase:
                                                sa.Column('data_id', sa.Integer,
                                                          sa.ForeignKey("data.id", name="fk_complied_release_data_id"),
                                                          nullable=False),
+                                               sa.Index('compiled_release_ocid_idx', 'ocid')
                                                )
 
         self.release_check_table = sa.Table('release_check', self.metadata,

--- a/ocdskingfisherprocess/maindatabase/migrations/versions/d8a32a738af4_index_on_release_and_record_file_item.py
+++ b/ocdskingfisherprocess/maindatabase/migrations/versions/d8a32a738af4_index_on_release_and_record_file_item.py
@@ -1,0 +1,24 @@
+"""index on release and record file item
+
+Revision ID: d8a32a738af4
+Revises: 3811a084cc66
+Create Date: 2019-03-26 17:51:45.836678
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'd8a32a738af4'
+down_revision = '3811a084cc66'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('release_collection_file_item_id_idx', 'release', ['collection_file_item_id'])
+    op.create_index('record_collection_file_item_id_idx', 'record', ['collection_file_item_id'])
+
+
+def downgrade():
+    op.drop_index('release_collection_file_item_id_idx')
+    op.drop_index('record_collection_file_item_id_idx')

--- a/ocdskingfisherprocess/maindatabase/migrations/versions/d8a32a738af4_indexs_on_release_and_record.py
+++ b/ocdskingfisherprocess/maindatabase/migrations/versions/d8a32a738af4_indexs_on_release_and_record.py
@@ -18,7 +18,15 @@ def upgrade():
     op.create_index('release_collection_file_item_id_idx', 'release', ['collection_file_item_id'])
     op.create_index('record_collection_file_item_id_idx', 'record', ['collection_file_item_id'])
 
+    op.create_index('release_ocid_idx', 'release', ['ocid'])
+    op.create_index('record_ocid_idx', 'record', ['ocid'])
+    op.create_index('compiled_release_ocid_idx', 'compiled_release', ['ocid'])
+
 
 def downgrade():
     op.drop_index('release_collection_file_item_id_idx')
     op.drop_index('record_collection_file_item_id_idx')
+
+    op.drop_index('release_ocid_idx')
+    op.drop_index('record_ocid_idx')
+    op.drop_index('compiled_release_ocid_idx')


### PR DESCRIPTION
Makes transforms run much faster as they are joining from the
collection_file_item table to the release/record tables (which are very
large)

Also compiling queries on ocid which is slow on large tables.