### PR TITLE
Use time_limit contextmanager

### DIFF
--- a/ocdskingfisherprocess/cli/commands/base.py
+++ b/ocdskingfisherprocess/cli/commands/base.py
@@ -1,5 +1,3 @@
-
-
 class CLICommand:
     command = ''
 
@@ -18,8 +16,13 @@ class CLICommand:
         subparser.add_argument("collection", help="Collection ID (Use list-collections command to find the ID)")
 
     def run_command_for_selecting_existing_collection(self, args):
-
         self.collection = self.database.get_collection(args.collection)
         if not self.collection:
             print("We can not find the collection that you requested!")
             quit(-1)
+
+
+class TimeLimitedCLICommand(CLICommand):
+    def configure_subparser(self, subparser):
+        subparser.add_argument('--runforseconds', type=int,
+                               help='Run for this many seconds only.')

--- a/ocdskingfisherprocess/cli/commands/check_collections.py
+++ b/ocdskingfisherprocess/cli/commands/check_collections.py
@@ -11,7 +11,7 @@ class CheckCollectionsCLICommand(TimeLimitedCLICommand):
     command = 'check-collections'
 
     def run_command(self, args):
-        with time_limit(args.runforseconds):
+        with time_limit(args.runforseconds, self.command):
             for collection in self.database.get_all_collections():
                 logger.info('Checking collection: {}'.format(collection.database_id))
                 checks = Checks(self.database, collection)

--- a/ocdskingfisherprocess/cli/commands/check_collections.py
+++ b/ocdskingfisherprocess/cli/commands/check_collections.py
@@ -1,39 +1,18 @@
-import ocdskingfisherprocess.database
-import ocdskingfisherprocess.cli.commands.base
+import logging
+
+from ocdskingfisherprocess.cli.commands.base import TimeLimitedCLICommand
+from ocdskingfisherprocess.cli.util import time_limit
 from ocdskingfisherprocess.checks import Checks
-import datetime
-from threading import Timer
-import os
+
+logger = logging.getLogger('ocdskingfisherprocess')
 
 
-class CheckCollectionsCLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
+class CheckCollectionsCLICommand(TimeLimitedCLICommand):
     command = 'check-collections'
 
-    def configure_subparser(self, subparser):
-        subparser.add_argument("--runforseconds",
-                               help="Run for this many seconds only.")
-
     def run_command(self, args):
-        run_until_timestamp = None
-        run_for_seconds = int(args.runforseconds) if args.runforseconds else 0
-        if run_for_seconds > 0:
-            run_until_timestamp = datetime.datetime.utcnow().timestamp() + run_for_seconds
-
-            # This is a safeguard - the process should stop itself but this will kill it if it does not.
-            def exitfunc():
-                os._exit(0)
-
-            Timer(run_for_seconds + 60, exitfunc).start()
-
-        for collection in self.database.get_all_collections():
-            if not args.quiet:
-                print("Collection " + str(collection.database_id))
-            checks = Checks(self.database, collection, run_until_timestamp=run_until_timestamp)
-            checks.process_all_files()
-            # Early return?
-            if run_until_timestamp and run_until_timestamp < datetime.datetime.utcnow().timestamp():
-                break
-
-        # If the code above took less than 60 seconds the process will stay open, waiting for the Timer to execute.
-        # So just kill it to make sure.
-        os._exit(0)
+        with time_limit(args.runforseconds):
+            for collection in self.database.get_all_collections():
+                logger.info('Checking collection: {}'.format(collection.database_id))
+                checks = Checks(self.database, collection)
+                checks.process_all_files()

--- a/ocdskingfisherprocess/cli/commands/process_redis_queue.py
+++ b/ocdskingfisherprocess/cli/commands/process_redis_queue.py
@@ -20,7 +20,7 @@ class ProcessRedisQueueCLICommand(TimeLimitedCLICommand):
         redis_conn = redis.Redis(host=self.config.redis_host, port=self.config.redis_port, db=self.config.redis_database)
         process_que_message = ProcessQueueMessage(database=self.database)
 
-        with time_limit(args.runforseconds):
+        with time_limit(args.runforseconds, self.command):
             while True:
                 data = redis_conn.blpop('kingfisher_work', timeout=10)
                 if data:

--- a/ocdskingfisherprocess/cli/commands/process_redis_queue.py
+++ b/ocdskingfisherprocess/cli/commands/process_redis_queue.py
@@ -1,56 +1,30 @@
-import datetime
-from threading import Timer
-import os
 import logging
 
 import redis
 
-import ocdskingfisherprocess.cli.commands.base
+from ocdskingfisherprocess.cli.commands.base import TimeLimitedCLICommand
+from ocdskingfisherprocess.cli.util import time_limit
 from ocdskingfisherprocess.redis import ProcessQueueMessage
 
+logger = logging.getLogger('ocdskingfisherprocess')
 
-class ProcessRedisQueueCLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
+
+class ProcessRedisQueueCLICommand(TimeLimitedCLICommand):
     command = 'process-redis-queue'
-
-    def configure_subparser(self, subparser):
-        subparser.add_argument("--runforseconds",
-                               help="Run for this many seconds only.")
 
     def run_command(self, args):
         if not self.config.is_redis_available():
-            print("No Redis is configured!")
+            logger.error("No Redis is configured!")
             return
-
-        run_until_timestamp = None
-        run_for_seconds = int(args.runforseconds) if args.runforseconds else 0
-        if run_for_seconds > 0:
-            run_until_timestamp = datetime.datetime.utcnow().timestamp() + run_for_seconds
-
-            # This is a safeguard - the process should stop itself but this will kill it if it does not.
-            def exitfunc():
-                os._exit(0)
-
-            Timer(run_for_seconds + 60, exitfunc).start()
 
         redis_conn = redis.Redis(host=self.config.redis_host, port=self.config.redis_port, db=self.config.redis_database)
         process_que_message = ProcessQueueMessage(database=self.database)
-        logger = logging.getLogger('ocdskingfisher.redis-queue')
 
-        run = True
-        while run:
-            data = redis_conn.blpop("kingfisher_work", timeout=10)
-            if data:
-                message = data[1].decode('ascii')
-                if not args.quiet:
-                    print("Got Message: " + message)
-                logger.info("Got Message: " + message)
-                process_que_message.process(message, run_until_timestamp=run_until_timestamp)
-                if not args.quiet:
-                    print("Processed!")
-            # Early return?
-            if run_until_timestamp and run_until_timestamp < datetime.datetime.utcnow().timestamp():
-                run = False
-
-        # If the code above took less than 60 seconds the process will stay open, waiting for the Timer to execute.
-        # So just kill it to make sure.
-        os._exit(0)
+        with time_limit(args.runforseconds):
+            while True:
+                data = redis_conn.blpop('kingfisher_work', timeout=10)
+                if data:
+                    message = data[1].decode('ascii')
+                    logger.info('Got Message: {}'.format(message))
+                    process_que_message.process(message)
+                    logger.info('Processed!')

--- a/ocdskingfisherprocess/cli/commands/transform_collections.py
+++ b/ocdskingfisherprocess/cli/commands/transform_collections.py
@@ -1,41 +1,20 @@
-import ocdskingfisherprocess.database
-import ocdskingfisherprocess.cli.commands.base
+import logging
+
+from ocdskingfisherprocess.cli.commands.base import TimeLimitedCLICommand
+from ocdskingfisherprocess.cli.util import time_limit
 from ocdskingfisherprocess.transform.util import get_transform_instance
-import datetime
-from threading import Timer
-import os
+
+logger = logging.getLogger('ocdskingfisherprocess')
 
 
-class TransformCollectionsCLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
+class TransformCollectionsCLICommand(TimeLimitedCLICommand):
     command = 'transform-collections'
 
-    def configure_subparser(self, subparser):
-        subparser.add_argument("--runforseconds",
-                               help="Run for this many seconds only.")
-
     def run_command(self, args):
-        run_until_timestamp = None
-        run_for_seconds = int(args.runforseconds) if args.runforseconds else 0
-        if run_for_seconds > 0:
-            run_until_timestamp = datetime.datetime.utcnow().timestamp() + run_for_seconds
-
-            # This is a safeguard - the process should stop itself but this will kill it if it does not.
-            def exitfunc():
-                os._exit(0)
-
-            Timer(run_for_seconds + 60, exitfunc).start()
-
-        for collection in self.database.get_all_collections():
-            if collection.transform_type:
-                if not args.quiet:
-                    print("Collection " + str(collection.database_id))
-                transform = get_transform_instance(collection.transform_type, self.config, self.database,
-                                                   collection, run_until_timestamp=run_until_timestamp)
-                transform.process()
-            # Early return?
-            if run_until_timestamp and run_until_timestamp < datetime.datetime.utcnow().timestamp():
-                break
-
-        # If the code above took less than 60 seconds the process will stay open, waiting for the Timer to execute.
-        # So just kill it to make sure.
-        os._exit(0)
+        with time_limit(args.runforseconds):
+            for collection in self.database.get_all_collections():
+                if collection.transform_type:
+                    logger.info('Transforming collection: {}'.format(collection.database_id))
+                    transform = get_transform_instance(collection.transform_type, self.config, self.database,
+                                                       collection)
+                    transform.process()

--- a/ocdskingfisherprocess/cli/commands/transform_collections.py
+++ b/ocdskingfisherprocess/cli/commands/transform_collections.py
@@ -11,7 +11,7 @@ class TransformCollectionsCLICommand(TimeLimitedCLICommand):
     command = 'transform-collections'
 
     def run_command(self, args):
-        with time_limit(args.runforseconds):
+        with time_limit(args.runforseconds, self.command):
             for collection in self.database.get_all_collections():
                 if collection.transform_type:
                     logger.info('Transforming collection: {}'.format(collection.database_id))

--- a/ocdskingfisherprocess/cli/util.py
+++ b/ocdskingfisherprocess/cli/util.py
@@ -31,7 +31,9 @@ def gather_cli_commands_instances(config=None, database=None):
 # See https://github.com/glenfant/stopit#comparing-thread-based-and-signal-based-timeout-control
 @contextmanager
 def time_limit(seconds, message):
-    if seconds > 0:
+    if seconds is None:
+        yield
+    elif seconds > 0:
         timer = threading.Timer(seconds, lambda: interrupt_main())  # raises KeyboardInterrupt
         timer.start()
         try:

--- a/ocdskingfisherprocess/redis.py
+++ b/ocdskingfisherprocess/redis.py
@@ -8,10 +8,10 @@ class ProcessQueueMessage:
     def __init__(self, database):
         self.database = database
 
-    def process(self, message_as_string, run_until_timestamp=None):
+    def process(self, message_as_string):
         message_as_data = json.loads(message_as_string)
         if message_as_data['type'] == 'collection-data-store-finished':
             collection = self.database.get_collection(message_as_data['collection_id'])
             if collection:
-                checks = Checks(self.database, collection, run_until_timestamp=run_until_timestamp)
+                checks = Checks(self.database, collection)
                 checks.process_all_files()

--- a/ocdskingfisherprocess/transform/base.py
+++ b/ocdskingfisherprocess/transform/base.py
@@ -3,14 +3,13 @@ from ocdskingfisherprocess.store import Store
 
 class BaseTransform():
 
-    def __init__(self, config, database, destination_collection, run_until_timestamp=None):
+    def __init__(self, config, database, destination_collection):
         self.config = config
         self.database = database
         self.destination_collection = destination_collection
         self.source_collection = self.database.get_collection(destination_collection.transform_from_collection_id)
         self.store = Store(config, database)
         self.store.set_collection(destination_collection)
-        self.run_until_timestamp = run_until_timestamp
 
     def process(self):
         # This is an "abstract" method - child classes should implement it!

--- a/ocdskingfisherprocess/transform/compile_releases.py
+++ b/ocdskingfisherprocess/transform/compile_releases.py
@@ -1,7 +1,6 @@
 from ocdskingfisherprocess.transform.base import BaseTransform
 import sqlalchemy as sa
 import ocdsmerge
-import datetime
 
 
 class CompileReleasesTransform(BaseTransform):
@@ -23,9 +22,6 @@ class CompileReleasesTransform(BaseTransform):
         for ocid in self.get_ocids():
             if not self.has_ocid_been_transformed(ocid):
                 self.process_ocid(ocid)
-            # Early return?
-            if self.run_until_timestamp and self.run_until_timestamp < datetime.datetime.utcnow().timestamp():
-                return
 
         # Mark Transform as finished
         self.database.mark_collection_store_done(self.destination_collection.database_id)

--- a/ocdskingfisherprocess/transform/upgrade_1_0_to_1_1.py
+++ b/ocdskingfisherprocess/transform/upgrade_1_0_to_1_1.py
@@ -1,4 +1,3 @@
-import datetime
 import sqlalchemy as sa
 from ocdskit.upgrade import upgrade_10_11
 
@@ -20,9 +19,6 @@ class Upgrade10To11Transform(BaseTransform):
         # Do the work ...
         for file_model in self.database.get_all_files_in_collection(self.source_collection.database_id):
             self.process_file(file_model)
-            # Early return?
-            if self.run_until_timestamp and self.run_until_timestamp < datetime.datetime.utcnow().timestamp():
-                return
 
         # If the source collection is finished, then we can mark the transform as finished
         if self.source_collection.store_end_at:
@@ -31,9 +27,6 @@ class Upgrade10To11Transform(BaseTransform):
     def process_file(self, file_model):
         for file_item_model in self.database.get_all_files_items_in_file(file_model):
             self.process_file_item(file_model, file_item_model)
-            # Early return?
-            if self.run_until_timestamp and self.run_until_timestamp < datetime.datetime.utcnow().timestamp():
-                return
 
     def process_file_item(self, file_model, file_item_model):
         with self.database.get_engine().begin() as connection:
@@ -45,9 +38,6 @@ class Upgrade10To11Transform(BaseTransform):
         for release_row in release_rows:
             if not self.has_release_id_been_done(release_row['id']):
                 self.process_release_row(file_model, file_item_model, release_row)
-            # Early return?
-            if self.run_until_timestamp and self.run_until_timestamp < datetime.datetime.utcnow().timestamp():
-                return
 
         del release_rows
 
@@ -60,9 +50,6 @@ class Upgrade10To11Transform(BaseTransform):
         for record_row in record_rows:
             if not self.has_record_id_been_done(record_row['id']):
                 self.process_record_row(file_model, file_item_model, record_row)
-            # Early return?
-            if self.run_until_timestamp and self.run_until_timestamp < datetime.datetime.utcnow().timestamp():
-                return
 
     def process_release_row(self, file_model, file_item_model, release_row):
         package = self.database.get_package_data(release_row.package_data_id)

--- a/ocdskingfisherprocess/transform/util.py
+++ b/ocdskingfisherprocess/transform/util.py
@@ -3,10 +3,10 @@ from ocdskingfisherprocess.transform.upgrade_1_0_to_1_1 import Upgrade10To11Tran
 from ocdskingfisherprocess.transform import TRANSFORM_TYPE_COMPILE_RELEASES, TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1
 
 
-def get_transform_instance(type, config, database, destination_collection, run_until_timestamp=None):
+def get_transform_instance(type, config, database, destination_collection):
     if type == TRANSFORM_TYPE_COMPILE_RELEASES:
-        return CompileReleasesTransform(config, database, destination_collection, run_until_timestamp=run_until_timestamp)
+        return CompileReleasesTransform(config, database, destination_collection)
     elif type == TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1:
-        return Upgrade10To11Transform(config, database, destination_collection, run_until_timestamp=run_until_timestamp)
+        return Upgrade10To11Transform(config, database, destination_collection)
     else:
         raise Exception("That transform type is not known")


### PR DESCRIPTION
… instead of requiring operations to check run_until_timestamp.

I don't see the advantage of having to check `run_until_timestamp` in a dozen locations (and counting), compared to just allowing an exception to be raised on a timer.

The only potential downside to this PR is if the operations are not safe to interrupt, but it looks like we have used transactions and have ordered operations in a way that is safe.

This PR also replaces some `print` with logger calls.

One possible improvement to this PR is to catch the TimeoutException in the CLI command, so that users / cronmail get a nice message without a backtrace.