### PR TITLE
Local-Load command mark collection store ended after load, optional f…

### DIFF
--- a/docs/cli/local-load.rst
+++ b/docs/cli/local-load.rst
@@ -20,4 +20,11 @@ It will load files with a default encoding of `utf-8`. You can change it with th
 
     python ocdskingfisher-process-cli local-load 2 /data/uk_contracts_finder release_package --encoding ISO-8859-1
 
-After loading, you should mark the collection storage as ended - see :doc:`end-collection-store`.
+By default, afterwards the collection store will be marked as ended.
+If you want to leave it open (eg. so you can load more files) use the optional flag `--keep-collection-store-open`:
+
+.. code-block:: shell-session
+
+    python ocdskingfisher-process-cli local-load --keep-collection-store-open 1 /data/moldova release_package
+
+If you want to manually end the store see :doc:`end-collection-store`.

--- a/ocdskingfisherprocess/cli/commands/local_load.py
+++ b/ocdskingfisherprocess/cli/commands/local_load.py
@@ -13,6 +13,10 @@ class CheckCLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
         subparser.add_argument("directory", help="Directory to load from")
         subparser.add_argument("filetype", help="Types of file in the directory")
         subparser.add_argument("--encoding", help="File encoding", default="utf-8")
+        subparser.add_argument("--keep-collection-store-open",
+                               help="Keep collection store open (default is to end it straight after)",
+                               default=False,
+                               action='store_true')
 
     def run_command(self, args):
 
@@ -46,3 +50,9 @@ class CheckCLICommand(ocdskingfisherprocess.cli.commands.base.CLICommand):
             )
 
         print("Done")
+
+        if args.keep_collection_store_open:
+            print("Not ending collection store as requested; you may want to use the end-collection-store command")
+        else:
+            self.database.mark_collection_store_done(self.collection.database_id)
+            print("And collection store ended!")


### PR DESCRIPTION
…lag to leave open.

https://github.com/open-contracting/kingfisher-process/issues/76