### PR TITLE
Relax requirements.in versions, to allow patch-level security updates.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,14 +1,12 @@
-flattentool
-libcove
-libcoveocds
-ocdskit==0.0.5 # Locked until non back compat changes are fixed
-Flask
 alembic
+blinker
+Flask
+flattentool
+libcoveocds
+ocdskit<0.1.0 # Locked until non-backwards-compatible changes are fixed
+ocdsmerge
 pgpasslib
 psycopg2
-ocdsmerge
-blinker
 redis
 sentry-sdk
-# Lock to 1.2 branch (1.3 branch has issues with an identifier being too long)
-SQLAlchemy==1.2.19
+SQLAlchemy<1.3 # 1.3 branch has issues with an identifier being too long

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,17 @@
-flattentool==0.8.0
-libcove==0.10.0
+alembic==1.2.1
+blinker==1.4
+Flask==1.1.1
+flattentool==0.9.0
 libcoveocds==0.7.3
 ocdskit==0.0.5
-Flask==1.1.1
-alembic==1.2.1
+ocdsmerge==0.5.8
 pgpasslib==1.1.0
-psycopg2==2.8.3
-ocdsmerge==0.5.7
-blinker==1.4
+psycopg2==2.8.4
 redis==3.3.11
-sentry-sdk==0.13.0
-# Lock to 1.2 branch (1.3 branch has issues with an identifier being too long)
+sentry-sdk==0.13.1
 SQLAlchemy==1.2.19
 ## The following requirements were added by pip freeze:
+attrs==19.3.0
 bleach==3.1.0
 cached-property==1.5.1
 certifi==2019.9.11
@@ -23,16 +22,20 @@ contextlib2==0.5.5
 Django==2.2.6
 et-xmlfile==1.0.1
 idna==2.8
+importlib-metadata==0.23
 itsdangerous==1.1.0
 jdcal==1.4.1
 Jinja2==2.10.3
 json-merge-patch==0.2
 jsonref==0.2
-jsonschema==2.6.0
+jsonschema==3.1.1
+libcove==0.11.0
 lxml==4.4.1
 Mako==1.1.0
 MarkupSafe==1.1.1
+more-itertools==7.2.0
 openpyxl==3.0.0
+pyrsistent==0.15.4
 python-dateutil==2.8.0
 python-editor==1.0.4
 pytz==2019.3
@@ -46,3 +49,4 @@ urllib3==1.25.6
 webencodings==0.5.1
 Werkzeug==0.16.0
 xmltodict==0.12.0
+zipp==0.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,21 +1,19 @@
-flattentool==0.8.0
-libcove==0.10.0
+alembic==1.2.1
+blinker==1.4
+Flask==1.1.1
+flattentool==0.9.0
 libcoveocds==0.7.3
 ocdskit==0.0.5
-Flask==1.1.1
-alembic==1.2.1
+ocdsmerge==0.5.8
 pgpasslib==1.1.0
-psycopg2==2.8.3
-ocdsmerge==0.5.7
-blinker==1.4
+psycopg2==2.8.4
 redis==3.3.11
-sentry-sdk==0.13.0
-# Lock to 1.2 branch (1.3 branch has issues with an identifier being too long)
+sentry-sdk==0.13.1
 SQLAlchemy==1.2.19
 
 coveralls==1.8.2
 flake8==3.7.8
-pytest==5.2.1
+pytest==5.2.2
 pytest-cov==2.8.1
 ## The following requirements were added by pip freeze:
 atomicwrites==1.3.0
@@ -39,7 +37,8 @@ jdcal==1.4.1
 Jinja2==2.10.3
 json-merge-patch==0.2
 jsonref==0.2
-jsonschema==2.6.0
+jsonschema==3.1.1
+libcove==0.11.0
 lxml==4.4.1
 Mako==1.1.0
 MarkupSafe==1.1.1
@@ -52,6 +51,7 @@ py==1.8.0
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pyparsing==2.4.2
+pyrsistent==0.15.4
 python-dateutil==2.8.0
 python-editor==1.0.4
 pytz==2019.3


### PR DESCRIPTION
Also:

- Remove libcove, as it is not a direct dependency, and as it is already required by libcoveocds.
- Sort packages.