### PR TITLE
Make tests easier to read, review and maintain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 env:
   global:
     - PGPORT=5433
-    - KINGFISHER_PROCESS_DB_URI='postgres:///travis'
+    - KINGFISHER_PROCESS_DB_URI='postgresql:///travis'
 services:
   - postgresql
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ install:
   - "pip install -r requirements_dev.txt"
 script:
   - "flake8 ocdskingfisherprocess/ ocdskingfisher-process-cli tests setup.py"
-  - "KINGFISHER_PROCESS_WEB_API_KEYS=1234 pytest --cov ocdskingfisherprocess"
+  - "pytest --cov ocdskingfisherprocess"
 after_success:
   coveralls

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -8,7 +8,7 @@ Run tests
 
 Run the tests with, for example:
 
-    KINGFISHER_PROCESS_DB_URI='postgres:///ocdskingfisher-test' pytest
+    KINGFISHER_PROCESS_DB_URI='postgresql:///ocdskingfisher-test' pytest
 
 Create migrations
 -----------------

--- a/docs/requirements-install.rst
+++ b/docs/requirements-install.rst
@@ -45,7 +45,7 @@ Create a UTF8-encoded PostgreSQL database and give the user write access, for ex
 
 Set the tool's database connection setting, replacing at least ``PASSWORD`` in this example::
 
-    export KINGFISHER_PROCESS_DB_URI='postgres://ocdskingfisher:PASSWORD@localhost/ocdskingfisher'
+    export KINGFISHER_PROCESS_DB_URI='postgresql://ocdskingfisher:PASSWORD@localhost/ocdskingfisher'
 
 .. note::
 

--- a/ocdskingfisher-process-cli
+++ b/ocdskingfisher-process-cli
@@ -1,55 +1,5 @@
 #!/usr/bin/env python
-import argparse
-import json
-import logging
-import logging.config
-import os
-import sentry_sdk
-
-import ocdskingfisherprocess.cli.util
-import ocdskingfisherprocess.config
-import ocdskingfisherprocess.signals.signals
-from ocdskingfisherprocess.database import DataBase
-
-
-def main():
-
-    config = ocdskingfisherprocess.config.Config()
-    config.load_user_config()
-
-    if config.sentry_dsn:
-        sentry_sdk.init(config.sentry_dsn)
-
-    database = DataBase(config)
-
-    ocdskingfisherprocess.signals.signals.setup_signals(config, database)
-
-    logging_config_file_full_path = os.path.expanduser('~/.config/ocdskingfisher-process/logging.json')
-    if os.path.isfile(logging_config_file_full_path):
-        with open(logging_config_file_full_path) as f:
-            logging.config.dictConfig(json.load(f))
-
-    logger = logging.getLogger('ocdskingfisher.cli')
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--quiet", help="remove output",
-                        action="store_true")
-
-    subparsers = parser.add_subparsers(dest='subcommand')
-
-    commands = ocdskingfisherprocess.cli.util.gather_cli_commands_instances(config=config, database=database)
-
-    for command in commands.values():
-        command.configure_subparser(subparsers.add_parser(command.command))
-
-    args = parser.parse_args()
-
-    if args.subcommand and args.subcommand in commands.keys():
-        logger.info("Running CLI command " + args.subcommand + " " + repr(args))
-        commands[args.subcommand].run_command(args)
-    else:
-        print("Please select a subcommand (try --help)")
-
+from ocdskingfisherprocess.cli.main import main
 
 if __name__ == '__main__':
     main()

--- a/ocdskingfisherprocess/cli/main.py
+++ b/ocdskingfisherprocess/cli/main.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+import logging
+import logging.config
+import os
+import sentry_sdk
+
+import ocdskingfisherprocess.cli.util
+import ocdskingfisherprocess.config
+import ocdskingfisherprocess.signals.signals
+from ocdskingfisherprocess.database import DataBase
+
+
+def main():
+
+    config = ocdskingfisherprocess.config.Config()
+    config.load_user_config()
+
+    if config.sentry_dsn:
+        sentry_sdk.init(config.sentry_dsn)
+
+    database = DataBase(config)
+
+    ocdskingfisherprocess.signals.signals.setup_signals(config, database)
+
+    logging_config_file_full_path = os.path.expanduser('~/.config/ocdskingfisher-process/logging.json')
+    if os.path.isfile(logging_config_file_full_path):
+        with open(logging_config_file_full_path) as f:
+            logging.config.dictConfig(json.load(f))
+
+    logger = logging.getLogger('ocdskingfisher.cli')
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quiet", help="remove output",
+                        action="store_true")
+
+    subparsers = parser.add_subparsers(dest='subcommand')
+
+    commands = ocdskingfisherprocess.cli.util.gather_cli_commands_instances(config=config, database=database)
+
+    for command in commands.values():
+        command.configure_subparser(subparsers.add_parser(command.command))
+
+    args = parser.parse_args()
+
+    if args.subcommand and args.subcommand in commands.keys():
+        logger.info("Running CLI command " + args.subcommand + " " + repr(args))
+        commands[args.subcommand].run_command(args)
+    else:
+        print("Please select a subcommand (try --help)")

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,8 +1,14 @@
-from ocdskingfisherprocess.database import DataBase
+import os
+from datetime import datetime
+
+import sqlalchemy as sa
+
 from ocdskingfisherprocess.config import Config
-from ocdskingfisherprocess.web.app import create_app
+from ocdskingfisherprocess.database import DataBase
 from ocdskingfisherprocess.signals import KINGFISHER_SIGNALS
 from ocdskingfisherprocess.signals.signals import setup_signals
+from ocdskingfisherprocess.store import Store
+from ocdskingfisherprocess.web.app import create_app
 
 
 def _reset_signals():
@@ -31,13 +37,74 @@ class AbstractDataBaseTest(BaseTest):
         self.database.delete_tables()
         self.database.create_tables()
 
+    def assert_row_counts(self, connection, counts):
+        """
+        Asserts that the tables contain the numbers of rows.
+        """
+        for table, count in counts.items():
+            self.assert_row_count(connection, table, count)
+
+    def assert_row_count(self, connection, table, count):
+        """
+        Asserts that the table contains the number of rows, and returns the result.
+        """
+        s = sa.sql.select([getattr(self.database, table + '_table')])
+        result = connection.execute(s)
+        assert result.rowcount == count
+
+        return result
+
 
 class BaseDataBaseTest(AbstractDataBaseTest):
+    """
+    The base class for all tests that interact with the database.
+
+    To setup the collection, implement a ``setup_collection`` instance method that accepts the collection ID as its
+    only argument.
+    """
+
     def setup_method(self, test_method):
         super().setup_method(test_method)
 
         _reset_signals()
         setup_signals(self.config, self.database)
+
+    def get_collection_and_store_file(self, basename, data_type):
+        """
+        Creates and configures a collection, stores a file, and returns the collection ID and collection.
+        """
+        collection_id = self.database.get_or_create_collection_id('test', datetime.now(), False)
+        self.setup_collection(collection_id)
+
+        collection = self.database.get_collection(collection_id)
+        store = Store(self.config, self.database)
+        store.set_collection(collection)
+
+        filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', basename)
+        store.store_file_from_local('test.json', 'http://example.com', data_type, 'utf-8', filename)
+
+        return collection_id, collection
+
+    def get_transformed_collection(self, source_collection_id, source_collection, transform_type):
+        """
+        Creates a transformed collection, and returns the collection ID and collection.
+        """
+        collection_id = self.database.get_or_create_collection_id(
+            source_collection.source_id,
+            source_collection.data_version,
+            source_collection.sample,
+            transform_from_collection_id=source_collection_id,
+            transform_type=transform_type)
+
+        collection = self.database.get_collection(collection_id)
+
+        return collection_id, collection
+
+    def setup_collection(self, collection_id):
+        """
+        Implement this method in a subclass to change the collection's configuration.
+        """
+        pass
 
 
 class BaseWebTest(AbstractDataBaseTest):

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,54 +10,43 @@ def _reset_signals():
 
 
 class BaseTest:
-
     def alter_config(self):
+        """
+        Implement this method in a subclass to edit ``self.config``.
+        """
         pass
 
+    # https://docs.pytest.org/en/latest/xunit_setup.html#method-and-function-level-setup-teardown
     def setup_method(self, test_method):
-        # config
         self.config = Config()
         self.config.load_user_config()
         self.alter_config()
 
 
-class BaseDataBaseTest:
-
-    def alter_config(self):
-        pass
-
+class AbstractDataBaseTest(BaseTest):
     def setup_method(self, test_method):
-        # config
-        self.config = Config()
-        self.config.load_user_config()
-        self.alter_config()
-        # database
+        super().setup_method(test_method)
+
         self.database = DataBase(config=self.config)
         self.database.delete_tables()
         self.database.create_tables()
-        # signals
+
+
+class BaseDataBaseTest(AbstractDataBaseTest):
+    def setup_method(self, test_method):
+        super().setup_method(test_method)
+
         _reset_signals()
         setup_signals(self.config, self.database)
 
 
-class BaseWebTest:
-
-    def alter_config(self):
-        pass
-
+class BaseWebTest(AbstractDataBaseTest):
     def setup_method(self, test_method):
-        # config
-        self.config = Config()
-        self.config.load_user_config()
-        self.alter_config()
-        # database
-        self.database = DataBase(config=self.config)
-        self.database.delete_tables()
-        self.database.create_tables()
-        # signals
+        super().setup_method(test_method)
+
         _reset_signals()
         # don't call - setup_signals(self.config, self.database) - create_app will
-        # flask app
+
         self.webapp = create_app(config=self.config)
         self.webapp.config['TESTING'] = True
         self.flaskclient = self.webapp.test_client()

--- a/tests/test_can_delete.py
+++ b/tests/test_can_delete.py
@@ -4,7 +4,6 @@ from tests.base import BaseDataBaseTest
 
 
 class TestDelete(BaseDataBaseTest):
-
     def alter_config(self):
         self.config.run_standard_pipeline = False
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -33,7 +33,7 @@ class BaseTest(BaseDataBaseTest):
         self._process_files(collection, collection_id, table)
 
         # Running another time should have no effect.
-        if getattr(self, 'count', 0):
+        if self.count:
             self._process_files(collection, collection_id, table)
 
     def _process_files(self, collection, collection_id, table):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,837 +1,114 @@
-import datetime
-import os
-import sqlalchemy as sa
-from ocdskingfisherprocess.store import Store
-from tests.base import BaseDataBaseTest
 from ocdskingfisherprocess.checks import Checks
+from tests.base import BaseDataBaseTest
 
 
-class TestAllChecksOff(BaseDataBaseTest):
+class BaseTest(BaseDataBaseTest):
+    """
+    The base class for tests of the Checks class.
 
+    Set a ``count`` class attribute for the number of rows that are expected to be added to the table.
+
+    If you want to perform an additional test on the first added row, define a ``check`` static method that accepts the
+    row as its only argument and returns a boolean.
+
+    If you want to test using ``process_file_item_id`` instead of ``process_all_files``, define a ``file_item``
+    instance method that accepts a collection ID as its only argument and returns a file item.
+    """
     def alter_config(self):
         self.config.run_standard_pipeline = False
 
-    def test_records_via_process_all_files_method(self):
+    def test_records(self):
+        self.run('record_check', 'sample_1_0_record.json', 'record')
 
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        collection = self.database.get_collection(collection_id)
+    def test_releases(self):
+        self.run('release_check', 'sample_1_0_release.json', 'release_package')
 
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
+    def run(self, table, filename, data_type):
+        collection_id, collection = self.get_collection_and_store_file(filename, data_type)
 
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_record.json'
-        )
+        # Check that no files are processed yet.
+        self._check_number_of_check_results()
 
-        store.store_file_from_local("test.json", "http://example.com", "record", "utf-8", json_filename)
+        # Check that the files are processed as expected.
+        self._process_files(collection, collection_id, table)
 
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+        # Running another time should have no effect.
+        if getattr(self, 'count', 0):
+            self._process_files(collection, collection_id, table)
 
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
+    def _process_files(self, collection, collection_id, table):
         checks = Checks(self.database, collection)
-        checks.process_all_files()
 
-        # Check Number of check results
+        if hasattr(self, 'file_item'):
+            checks.process_file_item_id(self.file_item(collection_id).database_id)
+        else:
+            checks.process_all_files()
+
+        self._check_number_of_check_results(table)
+
+    def _check_number_of_check_results(self, table=None):
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-    def test_releases_via_process_all_files_method(self):
-
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_release.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+            for t in ('record_check', 'release_check', 'record_check_error', 'release_check_error'):
+                result = self.assert_row_count(connection, t, self.count if t == table else 0)
+                if t == table and hasattr(self, 'check'):
+                    data = result.fetchone()
+                    assert self.check(data)
 
 
-class TestCheckOn(BaseDataBaseTest):
+class TestAllChecksOff(BaseTest):
+    count = 0
 
-    def alter_config(self):
-        self.config.run_standard_pipeline = False
 
-    def test_records_via_process_all_files_method(self):
+class TestCheckOn(BaseTest):
+    count = 1
 
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
+    def setup_collection(self, collection_id):
         self.database.mark_collection_check_data(collection_id, True)
 
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_record.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "record", "utf-8", json_filename)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-            data = result.fetchone()
-            assert not data.override_schema_version
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks Again - that should be fine
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-            data = result.fetchone()
-            assert not data.override_schema_version
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-    def test_release_via_process_all_files_method(self):
-
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        self.database.mark_collection_check_data(collection_id, True)
-
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_release.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-            data = result.fetchone()
-            assert not data.override_schema_version
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks Again - that should be fine
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-            data = result.fetchone()
-            assert not data.override_schema_version
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+    @staticmethod
+    def check(data):
+        return not data.override_schema_version
 
 
-class TestCheckOlderThan11On(BaseDataBaseTest):
+class TestCheckOlderThan11On(BaseTest):
+    count = 1
 
-    def alter_config(self):
-        self.config.run_standard_pipeline = False
-
-    def test_records_via_process_all_files_method(self):
-
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
+    def setup_collection(self, collection_id):
         self.database.mark_collection_check_older_data_with_schema_version_1_1(collection_id, True)
 
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_record.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "record", "utf-8", json_filename)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-            data = result.fetchone()
-            assert '1.1' == data.override_schema_version
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks Again - that should be fine
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-            data = result.fetchone()
-            assert '1.1' == data.override_schema_version
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-    def test_release_via_process_all_files_method(self):
-
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        self.database.mark_collection_check_older_data_with_schema_version_1_1(collection_id, True)
-
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_release.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-            data = result.fetchone()
-            assert '1.1' == data.override_schema_version
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks Again - that should be fine
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-            data = result.fetchone()
-            assert '1.1' == data.override_schema_version
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+    @staticmethod
+    def check(data):
+        return '1.1' == data.override_schema_version
 
 
-class TestCheckAllOn(BaseDataBaseTest):
+class TestCheckAllOn(BaseTest):
+    count = 2
 
-    def alter_config(self):
-        self.config.run_standard_pipeline = False
-
-    def test_records_via_process_all_files_method(self):
-
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
+    def setup_collection(self, collection_id):
         self.database.mark_collection_check_data(collection_id, True)
         self.database.mark_collection_check_older_data_with_schema_version_1_1(collection_id, True)
 
-        collection = self.database.get_collection(collection_id)
 
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_record.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "record", "utf-8", json_filename)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks Again - that should be fine
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-    def test_releases_via_process_all_files_method(self):
-
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        self.database.mark_collection_check_data(collection_id, True)
-        self.database.mark_collection_check_older_data_with_schema_version_1_1(collection_id, True)
-
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_release.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks Again - that should be fine
-        checks = Checks(self.database, collection)
-        checks.process_all_files()
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-    def test_records_via_process_file_item_id_method(self):
-
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        self.database.mark_collection_check_data(collection_id, True)
-        self.database.mark_collection_check_older_data_with_schema_version_1_1(collection_id, True)
-
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_record.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "record", "utf-8", json_filename)
-
-        file_item = self.database.get_all_files_items_in_file(
-            self.database.get_all_files_in_collection(collection_id)[0]
-        )[0]
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_file_item_id(file_item.database_id)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks Again - that should be fine
-        checks = Checks(self.database, collection)
-        checks.process_file_item_id(file_item.database_id)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-    def test_releases_via_process_file_item_id_method(self):
-
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        self.database.mark_collection_check_data(collection_id, True)
-        self.database.mark_collection_check_older_data_with_schema_version_1_1(collection_id, True)
-
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_release.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        file_item = self.database.get_all_files_items_in_file(
-            self.database.get_all_files_in_collection(collection_id)[0]
-        )[0]
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks
-        checks = Checks(self.database, collection)
-        checks.process_file_item_id(file_item.database_id)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # Call Checks Again - that should be fine
-        checks = Checks(self.database, collection)
-        checks.process_file_item_id(file_item.database_id)
-
-        # Check Number of check results
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_check_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.record_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.release_check_error_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+class TestCheckAllOnFileItem(TestCheckAllOn):  # Unlike others, inherits from TestCheckAllOn.
+    def file_item(self, collection_id):
+        file = self.database.get_all_files_in_collection(collection_id)[0]
+        return self.database.get_all_files_items_in_file(file)[0]
 
 
 class TestCheck11NotSelected(BaseDataBaseTest):
-
     def alter_config(self):
         self.config.run_standard_pipeline = False
 
     def test_records_via_process_all_files_method(self):
+        collection_id, collection = self.get_collection_and_store_file(
+            'sample_1_1_record.json', 'record')
 
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_1_record.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "record", "utf-8", json_filename)
-
-        assert len([res for res in self.database.get_records_to_check(collection_id, override_schema_version='1.1')]) \
-            == 0
-        assert len([res for res in self.database.get_records_to_check(collection_id, override_schema_version='1.2')]) \
-            == 1
+        assert len([r for r in self.database.get_records_to_check(collection_id, override_schema_version='1.1')]) == 0
+        assert len([r for r in self.database.get_records_to_check(collection_id, override_schema_version='1.2')]) == 1
 
     def test_releases_via_process_all_files_method(self):
+        collection_id, collection = self.get_collection_and_store_file(
+            'sample_1_1_releases_multiple_with_same_ocid.json', 'release_package')
 
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        collection = self.database.get_collection(collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_1_releases_multiple_with_same_ocid.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        assert \
-            len([res for res in self.database.get_releases_to_check(collection_id, override_schema_version='1.1')]) \
-            == 0
-        # the file has 6 releases
-        assert \
-            len([res for res in self.database.get_releases_to_check(collection_id, override_schema_version='1.2')]) \
-            == 6
+        assert len([r for r in self.database.get_releases_to_check(collection_id, override_schema_version='1.1')]) == 0
+        assert len([r for r in self.database.get_releases_to_check(collection_id, override_schema_version='1.2')]) == 6

--- a/tests/test_collection_cached_columns.py
+++ b/tests/test_collection_cached_columns.py
@@ -1,97 +1,43 @@
-import datetime
-import os
 import sqlalchemy as sa
-from ocdskingfisherprocess.store import Store
-from tests.base import BaseDataBaseTest
-from ocdskingfisherprocess.transform.compile_releases import CompileReleasesTransform
+
 from ocdskingfisherprocess.transform import TRANSFORM_TYPE_COMPILE_RELEASES
+from ocdskingfisherprocess.transform.compile_releases import CompileReleasesTransform
+from tests.base import BaseDataBaseTest
 
 
 class TestCollectionCachedColums(BaseDataBaseTest):
-
     def alter_config(self):
         self.config.run_standard_pipeline = False
 
-    def test_releases(self):
-        # Make collection
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        collection = self.database.get_collection(collection_id)
-
-        # Load some data
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_1_releases_multiple_with_same_ocid.json'
-        )
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # test
-        self.database.update_collection_cached_columns(collection_id)
-
-        # check
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.collection_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-
-            data = result.fetchone()
-            assert 6 == data['cached_releases_count']
-
     def test_records(self):
-        # Make collection
-        collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        collection = self.database.get_collection(collection_id)
+        self.run('sample_1_0_record.json', 'record_package', 'cached_records_count', 1)
 
-        # Load some data
-        store = Store(self.config, self.database)
-        store.set_collection(collection)
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_record.json'
-        )
-        store.store_file_from_local("test.json", "http://example.com", "record_package", "utf-8", json_filename)
+    def test_releases(self):
+        self.run('sample_1_1_releases_multiple_with_same_ocid.json', 'release_package', 'cached_releases_count', 6)
 
-        # test
+    def run(self, filename, data_type, column, count):
+        collection_id, collection = self.get_collection_and_store_file(filename, data_type)
+
         self.database.update_collection_cached_columns(collection_id)
 
-        # check
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.collection_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
+            result = self.assert_row_count(connection, 'collection', 1)
             data = result.fetchone()
-            assert 1 == data['cached_records_count']
+            assert data[column] == count
 
     def test_compiled_releases(self):
-        # Make source collection
-        source_collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        source_collection = self.database.get_collection(source_collection_id)
+        source_collection_id, source_collection = self.get_collection_and_store_file(
+            'sample_1_1_releases_multiple_with_same_ocid.json', 'release_package')
 
-        # Load some data
-        store = Store(self.config, self.database)
-        store.set_collection(source_collection)
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_1_releases_multiple_with_same_ocid.json'
-        )
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Make destination collection
-        destination_collection_id = self.database.get_or_create_collection_id(
-            source_collection.source_id,
-            source_collection.data_version,
-            source_collection.sample,
-            transform_from_collection_id=source_collection_id,
-            transform_type=TRANSFORM_TYPE_COMPILE_RELEASES)
-        destination_collection = self.database.get_collection(destination_collection_id)
+        destination_collection_id, destination_collection = self.get_transformed_collection(
+            source_collection_id, source_collection, TRANSFORM_TYPE_COMPILE_RELEASES)
 
         # transform! Nothing should happen because source is not finished
         transform = CompileReleasesTransform(self.config, self.database, destination_collection)
         transform.process()
 
-        # check
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.compiled_release_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+            result = self.assert_row_count(connection, 'compiled_release', 0)
 
         # Mark source collection as finished
         self.database.mark_collection_store_done(source_collection_id)
@@ -104,14 +50,15 @@ class TestCollectionCachedColums(BaseDataBaseTest):
         self.database.update_collection_cached_columns(source_collection_id)
         self.database.update_collection_cached_columns(destination_collection_id)
 
-        # check
         with self.database.get_engine().begin() as connection:
             s = sa.sql.select([self.database.collection_table]).order_by(self.database.collection_table.columns.id)
             result = connection.execute(s)
             assert 2 == result.rowcount
+
             data = result.fetchone()
             assert 6 == data['cached_releases_count']
             assert 0 == data['cached_compiled_releases_count']
+
             data = result.fetchone()
             assert 0 == data['cached_releases_count']
             assert 1 == data['cached_compiled_releases_count']

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -8,12 +8,10 @@ from tests.base import BaseDataBaseTest
 
 
 class TestDelete(BaseDataBaseTest):
-
     def alter_config(self):
         self.config.run_standard_pipeline = False
 
     def test_a_single_collection(self):
-
         collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
         collection = self.database.get_collection(collection_id)
 
@@ -33,29 +31,14 @@ class TestDelete(BaseDataBaseTest):
 
         # Check Number of rows in various tables
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.collection_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-
-            s = sa.sql.select([self.database.collection_file_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.collection_file_item_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.data_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.package_data_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
+            self.assert_row_counts(connection, {
+                'collection': 1,
+                'collection_file': 2,
+                'collection_file_item': 2,
+                'record': 2,
+                'data': 2,
+                'package_data': 2,
+            })
 
         # Delete
         self.database.mark_collection_deleted_at(collection_id)
@@ -64,81 +47,36 @@ class TestDelete(BaseDataBaseTest):
 
         # Check Number of rows in various tables
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.collection_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-
-            s = sa.sql.select([self.database.collection_file_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.collection_file_item_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.data_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.package_data_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+            self.assert_row_counts(connection, {
+                'collection': 1,
+                'collection_file': 0,
+                'collection_file_item': 0,
+                'record': 0,
+                'data': 0,
+                'package_data': 0,
+            })
 
     def test_two_collections_with_upgrade_1_0_to_1_1(self):
-
-        # Source Collection
-
-        source_collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        source_collection = self.database.get_collection(source_collection_id)
-
-        store = Store(self.config, self.database)
-        store.set_collection(source_collection)
-
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_record.json'
-        )
-
-        store.store_file_from_local("test.json", "http://example.com", "record", "utf-8", json_filename)
+        source_collection_id, source_collection = self.get_collection_and_store_file(
+            'sample_1_0_record.json', 'record')
 
         self.database.mark_collection_store_done(source_collection_id)
 
-        # Destination Collection
-        destination_collection_id = self.database.get_or_create_collection_id(
-            "test",
-            datetime.datetime.now(),
-            False,
-            transform_from_collection_id=source_collection_id,
-            transform_type=TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
-        destination_collection = self.database.get_collection(destination_collection_id)
+        destination_collection_id, destination_collection = self.get_transformed_collection(
+            source_collection_id, source_collection, TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
 
         transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
         transform.process()
 
         # Check Number of rows in various tables
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.collection_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.collection_file_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.collection_file_item_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_record_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
+            self.assert_row_counts(connection, {
+                'collection': 2,
+                'collection_file': 2,
+                'collection_file_item': 2,
+                'record': 2,
+                'transform_upgrade_1_0_to_1_1_status_record': 1,
+            })
 
             s = sa.sql.select([self.database.data_table])
             result = connection.execute(s)
@@ -159,30 +97,12 @@ class TestDelete(BaseDataBaseTest):
 
         # Check Number of rows in various tables
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.collection_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.collection_file_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.collection_file_item_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_record_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.data_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.package_data_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+            self.assert_row_counts(connection, {
+                'collection': 2,
+                'collection_file': 0,
+                'collection_file_item': 0,
+                'record': 0,
+                'transform_upgrade_1_0_to_1_1_status_record': 0,
+                'data': 0,
+                'package_data': 0,
+            })

--- a/tests/test_standard_pipeline.py
+++ b/tests/test_standard_pipeline.py
@@ -4,7 +4,6 @@ from ocdskingfisherprocess.transform import TRANSFORM_TYPE_COMPILE_RELEASES, TRA
 
 
 class TestStandardPipelineOn(BaseDataBaseTest):
-
     def alter_config(self):
         self.config.run_standard_pipeline = True
 
@@ -15,8 +14,8 @@ class TestStandardPipelineOn(BaseDataBaseTest):
         collections = self.database.get_all_collections()
         assert 3 == len(collections)
 
-        assert None == collections[0].transform_type # noqa
-        assert None == collections[0].transform_from_collection_id # noqa
+        assert collections[0].transform_type is None
+        assert collections[0].transform_from_collection_id is None
 
         assert TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1 == collections[1].transform_type
         assert collections[0].database_id == collections[1].transform_from_collection_id
@@ -26,7 +25,6 @@ class TestStandardPipelineOn(BaseDataBaseTest):
 
 
 class TestStandardPipelineOff(BaseDataBaseTest):
-
     def alter_config(self):
         self.config.run_standard_pipeline = False
 

--- a/tests/test_transform_compile_releases.py
+++ b/tests/test_transform_compile_releases.py
@@ -1,148 +1,75 @@
-from tests.base import BaseDataBaseTest
-import datetime
-import sqlalchemy as sa
-from ocdskingfisherprocess.store import Store
-from ocdskingfisherprocess.transform.compile_releases import CompileReleasesTransform
 from ocdskingfisherprocess.transform import TRANSFORM_TYPE_COMPILE_RELEASES
-
-import os
+from ocdskingfisherprocess.transform.compile_releases import CompileReleasesTransform
+from tests.base import BaseDataBaseTest
 
 
 class TestTransformCompileReleases(BaseDataBaseTest):
-
     def test_1(self):
-        # Make source collection
-        source_collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        source_collection = self.database.get_collection(source_collection_id)
-
-        # Load some data
-        store = Store(self.config, self.database)
-        store.set_collection(source_collection)
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_1_releases_multiple_with_same_ocid.json'
-        )
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Make destination collection
-        destination_collection_id = self.database.get_or_create_collection_id(
-            source_collection.source_id,
-            source_collection.data_version,
-            source_collection.sample,
-            transform_from_collection_id=source_collection_id,
-            transform_type=TRANSFORM_TYPE_COMPILE_RELEASES)
-        destination_collection = self.database.get_collection(destination_collection_id)
+        source_collection_id, source_collection = self.get_collection_and_store_file(
+            'sample_1_1_releases_multiple_with_same_ocid.json', 'release_package')
+        destination_collection_id, destination_collection = self.get_transformed_collection(
+            source_collection_id, source_collection, TRANSFORM_TYPE_COMPILE_RELEASES)
 
         # transform! Nothing should happen because source is not finished
         transform = CompileReleasesTransform(self.config, self.database, destination_collection)
         transform.process()
-
-        # check
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.compiled_release_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+            self.assert_row_count(connection, 'compiled_release', 0)
 
-        # Mark source collection as finished
         self.database.mark_collection_store_done(source_collection_id)
 
         # transform! This should do the work.
         transform = CompileReleasesTransform(self.config, self.database, destination_collection)
         transform.process()
-
-        # check
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.compiled_release_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
+            self.assert_row_count(connection, 'compiled_release', 1)
 
         # transform again! This should be fine
         transform = CompileReleasesTransform(self.config, self.database, destination_collection)
         transform.process()
-
-        # check
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.compiled_release_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
+            self.assert_row_count(connection, 'compiled_release', 1)
 
         # destination collection should be closed
         destination_collection = self.database.get_collection(destination_collection_id)
-        assert destination_collection.store_end_at != None # noqa
+        assert destination_collection.store_end_at is not None
 
     def test_one_compiled(self):
+        source_collection_id, source_collection = self.get_collection_and_store_file(
+            'sample_1_1_releases_one_compiled.json', 'release_package')
 
-        # Make source collection
-        source_collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        source_collection = self.database.get_collection(source_collection_id)
-
-        # Load some data
-        store = Store(self.config, self.database)
-        store.set_collection(source_collection)
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_1_releases_one_compiled.json'
-        )
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Mark source collection as finished
         self.database.mark_collection_store_done(source_collection_id)
 
-        # Make destination collection
-        destination_collection_id = self.database.get_or_create_collection_id(
-            source_collection.source_id,
-            source_collection.data_version,
-            source_collection.sample,
-            transform_from_collection_id=source_collection_id,
-            transform_type=TRANSFORM_TYPE_COMPILE_RELEASES)
-        destination_collection = self.database.get_collection(destination_collection_id)
+        destination_collection_id, destination_collection = self.get_transformed_collection(
+            source_collection_id, source_collection, TRANSFORM_TYPE_COMPILE_RELEASES)
 
-        # transform!
         transform = CompileReleasesTransform(self.config, self.database, destination_collection)
         transform.process()
 
-        # Check warning
         files = self.database.get_all_files_in_collection(destination_collection_id)
         assert len(files) == 1
         file_items = self.database.get_all_files_items_in_file(files[0])
         assert len(file_items) == 1
         assert len(file_items[0].warnings) == 1
-        assert 'This already has one compiled release in the source! ' + \
-               'We have passed it through this transform unchanged.' \
-               == file_items[0].warnings[0]
+        assert 'This already has one compiled release in the source! We have passed it through this transform ' \
+               'unchanged.' == file_items[0].warnings[0]
 
     def test_two_compiled_with_same_ocid(self):
+        source_collection_id, source_collection = self.get_collection_and_store_file(
+            'sample_1_1_releases_two_compiled_with_same_ocid.json', 'release_package')
 
-        # Make source collection
-        source_collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        source_collection = self.database.get_collection(source_collection_id)
-
-        # Load some data
-        store = Store(self.config, self.database)
-        store.set_collection(source_collection)
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_1_releases_two_compiled_with_same_ocid.json'
-        )
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Mark source collection as finished
         self.database.mark_collection_store_done(source_collection_id)
 
-        # Make destination collection
-        destination_collection_id = self.database.get_or_create_collection_id(
-            source_collection.source_id,
-            source_collection.data_version,
-            source_collection.sample,
-            transform_from_collection_id=source_collection_id,
-            transform_type=TRANSFORM_TYPE_COMPILE_RELEASES)
-        destination_collection = self.database.get_collection(destination_collection_id)
+        destination_collection_id, destination_collection = self.get_transformed_collection(
+            source_collection_id, source_collection, TRANSFORM_TYPE_COMPILE_RELEASES)
 
-        # transform!
         transform = CompileReleasesTransform(self.config, self.database, destination_collection)
         transform.process()
 
-        # Check warning
         files = self.database.get_all_files_in_collection(destination_collection_id)
         assert len(files) == 1
         file_items = self.database.get_all_files_items_in_file(files[0])
         assert len(file_items) == 1
         assert len(file_items[0].warnings) == 1
-        assert 'This already has multiple compiled releases in the source! We have picked one at random and passed it through this transform unchanged.' == file_items[0].warnings[0]  # noqa
+        assert 'This already has multiple compiled releases in the source! We have picked one at random and passed ' \
+               'it through this transform unchanged.' == file_items[0].warnings[0]

--- a/tests/test_transform_upgrade_1_0_to_1_1.py
+++ b/tests/test_transform_upgrade_1_0_to_1_1.py
@@ -1,172 +1,55 @@
-from tests.base import BaseDataBaseTest
-import datetime
-import sqlalchemy as sa
-from ocdskingfisherprocess.store import Store
-from ocdskingfisherprocess.transform.upgrade_1_0_to_1_1 import Upgrade10To11Transform
 from ocdskingfisherprocess.transform import TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1
-import os
+from ocdskingfisherprocess.transform.upgrade_1_0_to_1_1 import Upgrade10To11Transform
+from tests.base import BaseDataBaseTest
 
 
 class TestTransformUpgrade10To11(BaseDataBaseTest):
+    def test_record(self):
+        self.run('sample_1_0_record.json', 'record_package', {
+            'record': 2,
+            'transform_upgrade_1_0_to_1_1_status_record': 1,
+        })
 
-    def test_record_1(self):
-        # Make source collection
-        source_collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        source_collection = self.database.get_collection(source_collection_id)
+    def test_release(self):
+        self.run('sample_1_0_releases.json', 'release_package', {
+                'release': 4,
+                'transform_upgrade_1_0_to_1_1_status_release': 2,
+        })
 
-        # Load some data
-        store = Store(self.config, self.database)
-        store.set_collection(source_collection)
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_record.json'
-        )
-        store.store_file_from_local("test.json", "http://example.com", "record_package", "utf-8", json_filename)
+    def run(self, filename, data_type, counts):
+        _counts = {
+            'record': 0,
+            'release': 0,
+            'transform_upgrade_1_0_to_1_1_status_record': 0,
+            'transform_upgrade_1_0_to_1_1_status_release': 0,
+        }
+        _counts.update(counts)
 
-        # Make destination collection
-        destination_collection_id = self.database.get_or_create_collection_id(
-            source_collection.source_id,
-            source_collection.data_version,
-            source_collection.sample,
-            transform_from_collection_id=source_collection_id,
-            transform_type=TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
+        source_collection_id, source_collection = self.get_collection_and_store_file(filename, data_type)
+        destination_collection_id, destination_collection = self.get_transformed_collection(
+            source_collection_id, source_collection, TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
+
+        self.transform(destination_collection, _counts)
+        # Running another time should have no effect.
+        self.transform(destination_collection, _counts)
+
+        # The destination collection shouldn't be closed, because the source is still open.
         destination_collection = self.database.get_collection(destination_collection_id)
+        assert destination_collection.store_end_at is None
 
-        # transform!
-        transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
-        transform.process()
-
-        # check
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.release_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_record_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_release_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # transform again! This should be fine
-        transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
-        transform.process()
-
-        # check
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-            s = sa.sql.select([self.database.release_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_record_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_release_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-        # destination collection will not be closed (because source is still open!)
-        destination_collection = self.database.get_collection(destination_collection_id)
-        assert destination_collection.store_end_at == None # noqa
-
-        # Mark source collection as finished
+        # Mark source collection as finished.
         self.database.mark_collection_store_done(source_collection_id)
 
-        # transform again! This should be fine
-        transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
+        # Running another time should have no effect.
+        self.transform(destination_collection, _counts)
+
+        # The destination collection should be closed.
+        destination_collection = self.database.get_collection(destination_collection_id)
+        assert destination_collection.store_end_at is not None
+
+    def transform(self, collection, counts):
+        transform = Upgrade10To11Transform(self.config, self.database, collection)
         transform.process()
 
-        # destination collection should be closed
-        destination_collection = self.database.get_collection(destination_collection_id)
-        assert destination_collection.store_end_at != None # noqa
-
-    def test_release_1(self):
-        # Make source collection
-        source_collection_id = self.database.get_or_create_collection_id("test", datetime.datetime.now(), False)
-        source_collection = self.database.get_collection(source_collection_id)
-
-        # Load some data
-        store = Store(self.config, self.database)
-        store.set_collection(source_collection)
-        json_filename = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'data', 'sample_1_0_releases.json'
-        )
-        store.store_file_from_local("test.json", "http://example.com", "release_package", "utf-8", json_filename)
-
-        # Make destination collection
-        destination_collection_id = self.database.get_or_create_collection_id(
-            source_collection.source_id,
-            source_collection.data_version,
-            source_collection.sample,
-            transform_from_collection_id=source_collection_id,
-            transform_type=TRANSFORM_TYPE_UPGRADE_1_0_TO_1_1)
-        destination_collection = self.database.get_collection(destination_collection_id)
-
-        # transform!
-        transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
-        transform.process()
-
-        # check
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.release_table])
-            result = connection.execute(s)
-            assert 4 == result.rowcount
-
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_record_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_release_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-        # transform again! This should be fine
-        transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
-        transform.process()
-
-        # check
-        with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.release_table])
-            result = connection.execute(s)
-            assert 4 == result.rowcount
-
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_record_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
-
-            s = sa.sql.select([self.database.transform_upgrade_1_0_to_1_1_status_release_table])
-            result = connection.execute(s)
-            assert 2 == result.rowcount
-
-        # destination collection will not be closed (because source is still open!)
-        destination_collection = self.database.get_collection(destination_collection_id)
-        assert destination_collection.store_end_at == None # noqa
-
-        # Mark source collection as finished
-        self.database.mark_collection_store_done(source_collection_id)
-
-        # transform!
-        transform = Upgrade10To11Transform(self.config, self.database, destination_collection)
-        transform.process()
-
-        # destination collection should be closed
-        destination_collection = self.database.get_collection(destination_collection_id)
-        assert destination_collection.store_end_at != None # noqa
+            self.assert_row_counts(connection, counts)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,40 +1,32 @@
-from ocdskingfisherprocess.util import parse_string_to_date_time, parse_string_to_boolean, FileToStore, \
-    control_codes_to_filter_out, control_code_to_filter_out_to_human_readable
 import os
 
+import pytest
 
-def test_parse_string_to_boolean_1():
-    assert True == parse_string_to_boolean("true") # noqa
-
-
-def test_parse_string_to_boolean_2():
-    assert False == parse_string_to_boolean("false") # noqa
+from ocdskingfisherprocess.util import parse_string_to_date_time, parse_string_to_boolean, FileToStore, \
+    control_codes_to_filter_out, control_code_to_filter_out_to_human_readable
 
 
-def test_parse_string_to_boolean_3():
-    assert True == parse_string_to_boolean("t") # noqa
+@pytest.mark.parametrize('value,expected', [
+    ('', False),
+    ('f', False),
+    ('false', False),
+    ('False', False),
+    ('t', True),
+    ('true', True),
+    ('True', True),
+    (None, False),
+])
+def test_parse_string_to_boolean(value, expected):
+    assert parse_string_to_boolean(value) is expected
 
 
-def test_parse_string_to_boolean_4():
-    assert False == parse_string_to_boolean("") # noqa
-
-
-def test_parse_string_to_boolean_5():
-    assert False == parse_string_to_boolean(None) # noqa
-
-
-def test_parse_string_to_boolean_6():
-    assert True == parse_string_to_boolean("True") # noqa
-
-
-def test_parse_string_to_date_time_1():
-    date = parse_string_to_date_time("2019-04-01 10:11:12")
-    assert "2019-04-01 10-11-12" == date.strftime("%Y-%m-%d %H-%M-%S")
-
-
-def test_parse_string_to_date_time_2():
-    date = parse_string_to_date_time("2019-04-01-10-11-12")
-    assert "2019-04-01 10-11-12" == date.strftime("%Y-%m-%d %H-%M-%S")
+@pytest.mark.parametrize('value,expected', [
+    ("2019-04-01 10:11:12", "2019-04-01 10-11-12"),
+    ("2019-04-01-10-11-12", "2019-04-01 10-11-12"),
+])
+def test_parse_string_to_date_time(value, expected):
+    date = parse_string_to_date_time(value)
+    assert date.strftime("%Y-%m-%d %H-%M-%S") == expected
 
 
 def test_file_to_store_sample_1_0_record_with_control_codes():

--- a/tests/test_web_api_v1.py
+++ b/tests/test_web_api_v1.py
@@ -1,8 +1,8 @@
-from tests.base import BaseWebTest
-import sqlalchemy as sa
 import io
-import os
 import json
+import os
+
+from tests.base import BaseWebTest
 
 
 class TestWebAPIV1(BaseWebTest):
@@ -70,14 +70,14 @@ class TestWebAPIV1(BaseWebTest):
         assert collection_id
 
         collection = self.database.get_collection(collection_id)
-        assert collection.store_start_at != None # noqa
-        assert collection.store_end_at == None # noqa
+        assert collection.store_start_at is not None
+        assert collection.store_end_at is None
 
         files = self.database.get_all_files_in_collection(collection_id)
         assert len(files) == 1
         assert files[0].filename == 'test.json'
         assert files[0].url == 'http://example.com'
-        assert files[0].errors == None # noqa
+        assert files[0].errors is None
 
         notes = self.database.get_all_notes_in_collection(collection_id)
         assert len(notes) == 0
@@ -106,8 +106,8 @@ class TestWebAPIV1(BaseWebTest):
         assert collection_id
 
         collection = self.database.get_collection(collection_id)
-        assert collection.store_start_at != None # noqa
-        assert collection.store_end_at == None # noqa
+        assert collection.store_start_at is not None
+        assert collection.store_end_at is None
 
         files = self.database.get_all_files_in_collection(collection_id)
         assert len(files) == 1
@@ -147,26 +147,23 @@ class TestWebAPIV1(BaseWebTest):
         assert collection_id
 
         collection = self.database.get_collection(collection_id)
-        assert collection.store_start_at != None # noqa
-        assert collection.store_end_at == None # noqa
+        assert collection.store_start_at is not None
+        assert collection.store_end_at is None
 
         files = self.database.get_all_files_in_collection(collection_id)
         assert len(files) == 1
         assert files[0].filename == 'test.json'
         assert files[0].url == 'http://example.com'
-        assert files[0].errors == None # noqa
+        assert files[0].errors is None
 
         notes = self.database.get_all_notes_in_collection(collection_id)
         assert len(notes) == 0
 
         with self.database.get_engine().begin() as connection:
-            s = sa.sql.select([self.database.record_table])
-            result = connection.execute(s)
-            assert 1 == result.rowcount
-
-            s = sa.sql.select([self.database.release_table])
-            result = connection.execute(s)
-            assert 0 == result.rowcount
+            self.assert_row_counts(connection, {
+                'record': 1,
+                'release': 0,
+            })
 
         # Make sure local file exists and was not removed!
         assert os.path.exists(json_filename)
@@ -195,14 +192,14 @@ class TestWebAPIV1(BaseWebTest):
         assert collection_id
 
         collection = self.database.get_collection(collection_id)
-        assert collection.store_start_at != None # noqa
-        assert collection.store_end_at == None # noqa
+        assert collection.store_start_at is not None
+        assert collection.store_end_at is None
 
         files = self.database.get_all_files_in_collection(collection_id)
         assert len(files) == 1
         assert files[0].filename == 'test.json'
         assert files[0].url == 'http://example.com'
-        assert files[0].errors == None # noqa
+        assert files[0].errors is None
 
         notes = self.database.get_all_notes_in_collection(collection_id)
         assert len(notes) == 0
@@ -244,8 +241,8 @@ class TestWebAPIV1(BaseWebTest):
         assert collection_id
 
         collection = self.database.get_collection(collection_id)
-        assert collection.store_start_at != None # noqa
-        assert collection.store_end_at != None # noqa
+        assert collection.store_start_at is not None
+        assert collection.store_end_at is not None
 
         notes = self.database.get_all_notes_in_collection(collection_id)
         assert len(notes) == 0
@@ -273,8 +270,8 @@ class TestWebAPIV1(BaseWebTest):
         assert collection_id
 
         collection = self.database.get_collection(collection_id)
-        assert collection.store_start_at != None # noqa
-        assert collection.store_end_at == None # noqa
+        assert collection.store_start_at is not None
+        assert collection.store_end_at is None
 
         files = self.database.get_all_files_in_collection(collection_id)
         assert len(files) == 1
@@ -282,8 +279,8 @@ class TestWebAPIV1(BaseWebTest):
         assert files[0].url == 'http://example.com'
         assert len(files[0].errors) == 1
         assert files[0].errors[0] == 'The error was ... because reasons.'
-        assert files[0].store_start_at == None # noqa
-        assert files[0].store_end_at == None # noqa
+        assert files[0].store_start_at is None
+        assert files[0].store_end_at is None
 
         notes = self.database.get_all_notes_in_collection(collection_id)
         assert len(notes) == 0
@@ -323,14 +320,14 @@ class TestWebAPIV1(BaseWebTest):
         assert collection_id
 
         collection = self.database.get_collection(collection_id)
-        assert collection.store_start_at != None # noqa
-        assert collection.store_end_at == None # noqa
+        assert collection.store_start_at is not None
+        assert collection.store_end_at is None
 
         files = self.database.get_all_files_in_collection(collection_id)
         assert len(files) == 1
         assert files[0].filename == 'test.json'
         assert files[0].url == 'http://example.com'
-        assert files[0].errors == None # noqa
+        assert files[0].errors is None
 
         file_items = self.database.get_all_files_items_in_file(files[0])
         assert len(file_items) == 1
@@ -387,18 +384,18 @@ class TestWebAPIV1(BaseWebTest):
         assert collection_id
 
         collection = self.database.get_collection(collection_id)
-        assert collection.store_start_at != None # noqa
-        assert collection.store_end_at == None # noqa
+        assert collection.store_start_at is not None
+        assert collection.store_end_at is None
 
         files = self.database.get_all_files_in_collection(collection_id)
         assert len(files) == 1
         assert files[0].filename == 'test.json'
         assert files[0].url == 'http://example.com'
-        assert files[0].errors == None # noqa
+        assert files[0].errors is None
 
         file_items = self.database.get_all_files_items_in_file(files[0])
         assert len(file_items) == 2
-        assert file_items[0].errors == None # noqa
+        assert file_items[0].errors is None
         assert file_items[1].errors == ['Release list not found']
 
         notes = self.database.get_all_notes_in_collection(collection_id)

--- a/tests/test_web_api_v1.py
+++ b/tests/test_web_api_v1.py
@@ -3,10 +3,11 @@ import sqlalchemy as sa
 import io
 import os
 import json
-import random
 
 
 class TestWebAPIV1(BaseWebTest):
+    def alter_config(self):
+        self.config.web_api_keys = '1234'
 
     def test_api_v1_bad_key(self):
         # Call
@@ -20,14 +21,10 @@ class TestWebAPIV1(BaseWebTest):
             'file': (io.BytesIO(b' {"valid_data": "Totally. It totally is."}'), "data.json")
         }
 
-        not_a_key = str(random.randint(100, 100000000000))
-        while not_a_key in self.config.web_api_keys:
-            not_a_key = str(random.randint(100, 100000000000))
-
         result = self.flaskclient.post('/api/v1/submit/file/',
                                        data=data,
                                        content_type='multipart/form-data',
-                                       headers={'Authorization': 'ApiKey ' + not_a_key})
+                                       headers={'Authorization': 'ApiKey bad-key'})
 
         assert result.status_code == 401
 

--- a/tests/test_web_api_v1_collection_notes.py
+++ b/tests/test_web_api_v1_collection_notes.py
@@ -4,6 +4,8 @@ from tests.base import BaseWebTest
 
 
 class TestWebAPIV1CollectionNotes(BaseWebTest):
+    def alter_config(self):
+        self.config.web_api_keys = '1234'
 
     def test_api_v1_submit_file(self):
         # Call First Time!


### PR DESCRIPTION
I wanted to add some integration tests (before attempting any changes to the queuing behavior), and wanted to understand how the current tests worked in order to add new ones, but it was very difficult to determine what each test was doing when, like in `tests/test_check.py`, there were 837 lines, but only about 100 that were unique to the tests.

This PR refactors the tests to be easier to read.

There is still a lot of duplication in test_web_api_v1* but since that's not the part of the project for which I want to add tests, I haven't refactored those.