### PR TITLE
Change migration to no longer create views

### DIFF
--- a/ocdskingfisherprocess/maindatabase/migrations/versions/413c84a833f5_add_collection_id_2.py
+++ b/ocdskingfisherprocess/maindatabase/migrations/versions/413c84a833f5_add_collection_id_2.py
@@ -16,15 +16,25 @@ depends_on = None
 
 
 def upgrade():
-    op.execute(
-        "UPDATE record SET collection_id = record_with_collection.collection_id "
-        "FROM record_with_collection WHERE record.id = record_with_collection.id")
-    op.execute(
-        "UPDATE release SET collection_id = release_with_collection.collection_id "
-        "FROM release_with_collection WHERE release.id = release_with_collection.id")
-    op.execute(
-        "UPDATE compiled_release SET collection_id = compiled_release_with_collection.collection_id "
-        "FROM compiled_release_with_collection WHERE compiled_release.id = compiled_release_with_collection.id")
+    conn = op.get_bind()
+
+    res = conn.execute("SELECT 1 FROM information_schema.tables WHERE table_name = 'record_with_collection'")
+    if res.scalar():
+        op.execute(
+            "UPDATE record SET collection_id = record_with_collection.collection_id "
+            "FROM record_with_collection WHERE record.id = record_with_collection.id")
+
+    res = conn.execute("SELECT 1 FROM information_schema.tables WHERE table_name = 'release_with_collection'")
+    if res.scalar():
+        op.execute(
+            "UPDATE release SET collection_id = release_with_collection.collection_id "
+            "FROM release_with_collection WHERE release.id = release_with_collection.id")
+
+    res = conn.execute("SELECT 1 FROM information_schema.tables WHERE table_name = 'compiled_release_with_collection'")
+    if res.scalar():
+        op.execute(
+            "UPDATE compiled_release SET collection_id = compiled_release_with_collection.collection_id "
+            "FROM compiled_release_with_collection WHERE compiled_release.id = compiled_release_with_collection.id")
 
     op.alter_column('record', 'collection_id', nullable=False)
     op.alter_column('release', 'collection_id', nullable=False)

--- a/ocdskingfisherprocess/maindatabase/migrations/versions/aef60ba6c0bc_view.py
+++ b/ocdskingfisherprocess/maindatabase/migrations/versions/aef60ba6c0bc_view.py
@@ -5,8 +5,6 @@ Revises: a9e65f49b868
 Create Date: 2019-02-06 14:19:41.539672
 
 """
-from alembic import op
-from sqlalchemy.sql import text
 
 # revision identifiers, used by Alembic.
 revision = 'aef60ba6c0bc'
@@ -16,67 +14,8 @@ depends_on = None
 
 
 def upgrade():
-    conn = op.get_bind()
-    conn.execute(
-        text(
-            """
-                CREATE VIEW release_with_collection
-                AS
-                SELECT
-                release.id,
-                release.collection_file_item_id,
-                release.release_id,
-                release.ocid,
-                release.data_id,
-                release.package_data_id,
-                collection_file.collection_id AS collection_id
-                FROM release
-                JOIN collection_file_item on collection_file_item.id = release.collection_file_item_id
-                JOIN collection_file on collection_file.id = collection_file_item.collection_file_id
-            """
-        )
-    )
-
-    conn.execute(
-        text(
-            """
-                CREATE VIEW record_with_collection
-                AS
-                SELECT
-                record.id,
-                record.collection_file_item_id,
-                record.ocid,
-                record.data_id,
-                record.package_data_id,
-                collection_file.collection_id AS collection_id
-                FROM record
-                JOIN collection_file_item on collection_file_item.id = record.collection_file_item_id
-                JOIN collection_file on collection_file.id = collection_file_item.collection_file_id
-            """
-        )
-    )
-
-    conn.execute(
-        text(
-            """
-                CREATE VIEW compiled_release_with_collection
-                AS
-                SELECT
-                compiled_release.id,
-                compiled_release.collection_file_item_id,
-                compiled_release.ocid,
-                compiled_release.data_id,
-                collection_file.collection_id AS collection_id
-                FROM compiled_release
-                JOIN collection_file_item on collection_file_item.id = compiled_release.collection_file_item_id
-                JOIN collection_file on collection_file.id = collection_file_item.collection_file_id
-            """
-        )
-    )
+    pass
 
 
 def downgrade():
-    conn = op.get_bind()
-    conn.execute(text("""DROP VIEW IF EXISTS release_with_collection"""))
-    conn.execute(text("""DROP VIEW IF EXISTS record_with_collection"""))
-    conn.execute(text("""DROP VIEW IF EXISTS compiled_release_with_collection"""))
+    pass


### PR DESCRIPTION
The app no longer needs them after #255. The app shouldn't be creating tables, views, etc. that it doesn't use.

Since some old notebooks might use the views, I chose not to add a migration to drop the views.

Since the app has later migrations that refer to this migration, I just deleted its contents.

With respect to our deployment, the result is that it is as though the views were created manually, which is fine. We don't need Process to forever be accountable for creating the deprecated views…

Related https://github.com/open-contracting/kingfisher-views/issues/62