### PR TITLE
checker removal

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -177,6 +177,7 @@ LOGGING = {
         "process": {
             "handlers": ["console"],
             "level": os.getenv("LOG_LEVEL", "INFO"),
+            "propagate": False,
         },
     },
 }

--- a/core/settings.py
+++ b/core/settings.py
@@ -255,4 +255,4 @@ KINGFISHER_COLLECT_FILES_STORE = os.getenv(
     "KINGFISHER_COLLECT_FILES_STORE", "/data" if production else BASE_DIR / "data"
 )
 
-ENABLE_CHECKER = os.getenv("ENABLE_CHECKER", 'true').lower() in ('true', '1', 't', 'T')
+ENABLE_CHECKER = os.getenv("ENABLE_CHECKER", "true").lower() in ("true", "1", "t", "T")

--- a/core/settings.py
+++ b/core/settings.py
@@ -254,3 +254,5 @@ SCRAPYD = {
 KINGFISHER_COLLECT_FILES_STORE = os.getenv(
     "KINGFISHER_COLLECT_FILES_STORE", "/data" if production else BASE_DIR / "data"
 )
+
+ENABLE_CHECKER = os.getenv("ENABLE_CHECKER", 'true').lower() in ('true', '1', 't', 'T')

--- a/core/settings.py
+++ b/core/settings.py
@@ -255,4 +255,4 @@ KINGFISHER_COLLECT_FILES_STORE = os.getenv(
     "KINGFISHER_COLLECT_FILES_STORE", "/data" if production else BASE_DIR / "data"
 )
 
-ENABLE_CHECKER = os.getenv("ENABLE_CHECKER", "true").lower() in ("true", "1", "t", "T")
+ENABLE_CHECKER = "ENABLE_CHECKER" in os.environ

--- a/process/management/commands/checker.py
+++ b/process/management/commands/checker.py
@@ -1,6 +1,8 @@
 import json
+import sys
 import traceback
 
+from django.conf import settings
 from django.db import transaction
 
 from process.exceptions import AlreadyExists
@@ -16,6 +18,10 @@ class Command(BaseWorker):
 
     def __init__(self):
         super().__init__(self.worker_name)
+
+        if not settings.ENABLE_CHECKER:
+            self.logger.error("Checker is disabled in settings - see ENABLE_CHECKER value.")
+            sys.exit(1)
 
     def process(self, connection, channel, delivery_tag, body):
         input_message = json.loads(body.decode("utf8"))

--- a/process/management/commands/checker.py
+++ b/process/management/commands/checker.py
@@ -1,8 +1,8 @@
 import json
-import sys
 import traceback
 
 from django.conf import settings
+from django.core.management.base import CommandError
 from django.db import transaction
 
 from process.exceptions import AlreadyExists
@@ -20,8 +20,7 @@ class Command(BaseWorker):
         super().__init__(self.worker_name)
 
         if not settings.ENABLE_CHECKER:
-            self.logger.error("Checker is disabled in settings - see ENABLE_CHECKER value.")
-            sys.exit(1)
+            raise CommandError("Refusing to start as checker is disabled in settings - see ENABLE_CHECKER value.")
 
     def process(self, connection, channel, delivery_tag, body):
         input_message = json.loads(body.decode("utf8"))

--- a/process/management/commands/close.py
+++ b/process/management/commands/close.py
@@ -56,7 +56,6 @@ class Command(BaseWorker):
         collection.save()
 
         upgraded_collection = collection.get_upgraded_collection()
-
         if upgraded_collection:
             upgraded_collection.store_end_at = Now()
             upgraded_collection.save()

--- a/process/management/commands/compiler.py
+++ b/process/management/commands/compiler.py
@@ -82,10 +82,13 @@ class Command(BaseWorker):
                     # plans compilation of this file (immedaite compilation - we dont have to wait for all records)
                     self._publish_records(connection, channel, collection_file)
                 else:
-                    self.logger.debug("""
+                    self.logger.debug(
+                        """
                                         There is no collection_file avalable for %s,
                                         Message probably comming from api endpoint collection_closed.
-                                        This log entry can be ignored for collections with record_packages.""", collection)
+                                        This log entry can be ignored for collections with record_packages.""",
+                        collection,
+                    )
 
             else:
                 self.logger.debug("Collection %s is not compilable.", collection)

--- a/process/management/commands/compiler.py
+++ b/process/management/commands/compiler.py
@@ -24,7 +24,7 @@ class Command(BaseWorker):
         collection = None
         collection_file = None
 
-        if "collection_id" in input_message:
+        if "source" in input_message and input_message["source"] == "collection_closed":
             # received message from collection closed api endpoint
             try:
                 collection = Collection.objects.get(pk=input_message["collection_id"])
@@ -57,6 +57,8 @@ class Command(BaseWorker):
 
         try:
             if compilable(collection.pk):
+                self.logger.debug("Collection %s is compilable.", collection)
+
                 if collection.data_type and collection.data_type["format"] == Collection.DataTypes.RELEASE_PACKAGE:
                     real_files_count = CollectionFile.objects.filter(collection=collection).count()
                     if collection.expected_files_count and collection.expected_files_count <= real_files_count:
@@ -79,6 +81,12 @@ class Command(BaseWorker):
                 ):
                     # plans compilation of this file (immedaite compilation - we dont have to wait for all records)
                     self._publish_records(connection, channel, collection_file)
+                else:
+                    self.logger.debug("""
+                                        There is no collection_file avalable for %s,
+                                        Message probably comming from api endpoint collection_closed.
+                                        This log entry can be ignored for collections with record_packages.""", collection)
+
             else:
                 self.logger.debug("Collection %s is not compilable.", collection)
         except Exception:

--- a/process/management/commands/compiler.py
+++ b/process/management/commands/compiler.py
@@ -84,9 +84,10 @@ class Command(BaseWorker):
                 else:
                     self.logger.debug(
                         """
-                                        There is no collection_file avalable for %s,
-                                        Message probably comming from api endpoint collection_closed.
-                                        This log entry can be ignored for collections with record_packages.""",
+                            There is no collection_file avalable for %s,
+                            Message probably comming from api endpoint collection_closed.
+                            This log entry can be ignored for collections with record_packages.
+                        """,
                         collection,
                     )
 

--- a/process/management/commands/file_worker.py
+++ b/process/management/commands/file_worker.py
@@ -29,7 +29,10 @@ class Command(BaseWorker):
 
             upgraded_collection_file_id = None
 
-            message = input_message
+            message = {
+                "collection_id": input_message["collection_id"],
+                "collection_file_id": input_message["collection_file_id"]
+            }
 
             with transaction.atomic():
                 upgraded_collection_file_id = process_file(collection_file_id)

--- a/process/management/commands/file_worker.py
+++ b/process/management/commands/file_worker.py
@@ -28,6 +28,9 @@ class Command(BaseWorker):
             self.logger.debug("Received message %s", input_message)
 
             upgraded_collection_file_id = None
+
+            message = input_message
+
             with transaction.atomic():
                 upgraded_collection_file_id = process_file(collection_file_id)
 
@@ -36,11 +39,11 @@ class Command(BaseWorker):
             if settings.ENABLE_CHECKER:
                 self._create_step(ProcessingStep.Types.CHECK, collection_id, collection_file_id=collection_file_id)
 
-            self._publish_async(connection, channel, json.dumps(input_message))
+            self._publish_async(connection, channel, json.dumps(message))
 
             # send upgraded collection file to further processing
             if upgraded_collection_file_id:
-                message = {"collection_file_id": upgraded_collection_file_id}
+                message["collection_file_id"] = upgraded_collection_file_id
 
                 if settings.ENABLE_CHECKER:
                     self._create_step(

--- a/process/management/commands/file_worker.py
+++ b/process/management/commands/file_worker.py
@@ -31,7 +31,7 @@ class Command(BaseWorker):
 
             message = {
                 "collection_id": input_message["collection_id"],
-                "collection_file_id": input_message["collection_file_id"]
+                "collection_file_id": input_message["collection_file_id"],
             }
 
             with transaction.atomic():

--- a/process/management/commands/finisher.py
+++ b/process/management/commands/finisher.py
@@ -18,7 +18,9 @@ class Command(BaseWorker):
 
     worker_name = "finisher"
 
-    consume_keys = ["checker", "release_compiler", "record_compiler", "collection_closed", "file_worker"]
+    # Read all messages that might be the final message. "file_worker" can be the final message if neither checking nor
+    # compiling are performed, and if the "collection_closed" message is processed before the "file_worker" message.
+    consume_keys = ["file_worker", "checker", "release_compiler", "record_compiler", "collection_closed"]
 
     def __init__(self):
         super().__init__(self.worker_name)
@@ -38,7 +40,6 @@ class Command(BaseWorker):
                         collection.store_end_at = Now()
 
                     collection.completed_at = Now()
-
                     collection.save()
 
                     # complete upgraded collection as well

--- a/process/management/commands/finisher.py
+++ b/process/management/commands/finisher.py
@@ -18,7 +18,7 @@ class Command(BaseWorker):
 
     worker_name = "finisher"
 
-    consume_keys = ["checker", "release_compiler", "record_compiler", "collection_closed"]
+    consume_keys = ["checker", "release_compiler", "record_compiler", "collection_closed", "file_worker"]
 
     def __init__(self):
         super().__init__(self.worker_name)
@@ -40,6 +40,13 @@ class Command(BaseWorker):
                     collection.completed_at = Now()
 
                     collection.save()
+
+                    # complete upgraded collection as well
+                    upgraded_collection = collection.get_upgraded_collection()
+                    if upgraded_collection:
+                        upgraded_collection.completed_at = Now()
+                        upgraded_collection.save()
+
                     self.logger.debug("Processing of collection_id: %s finished. Set as completed.", collection_id)
                 else:
                     self.logger.debug("Processing of collection_id: %s not completable", collection_id)

--- a/process/management/commands/finisher.py
+++ b/process/management/commands/finisher.py
@@ -29,6 +29,8 @@ class Command(BaseWorker):
         try:
             self.logger.debug("Received message %s", input_message)
 
+            if "collection_id" not in input_message:
+                self.logger.debug("sfsdfsd")
             collection_id = input_message["collection_id"]
 
             with transaction.atomic():

--- a/process/management/commands/finisher.py
+++ b/process/management/commands/finisher.py
@@ -29,8 +29,6 @@ class Command(BaseWorker):
         try:
             self.logger.debug("Received message %s", input_message)
 
-            if "collection_id" not in input_message:
-                self.logger.debug("sfsdfsd")
             collection_id = input_message["collection_id"]
 
             with transaction.atomic():

--- a/process/management/commands/load.py
+++ b/process/management/commands/load.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import time
 
+from django.conf import settings
 from django.core.management.base import CommandError
 from django.db import transaction
 from django.db.models.functions import Now
@@ -112,6 +113,9 @@ class Command(BaseWorker):
             data_version = options["time"]
 
         try:
+            if not settings.ENABLE_CHECKER and options["check"]:
+                self.logger.error("Checker is disabled in settings - see ENABLE_CHECKER value.")
+
             collection, upgraded_collection, compiled_collection = create_collections(
                 options["source"],
                 data_version,

--- a/process/views/api.py
+++ b/process/views/api.py
@@ -27,7 +27,7 @@ def create_collection(request):
             )
 
         try:
-            if not settings.ENABLE_CHECKER and input_message.get("check", False):
+            if not settings.ENABLE_CHECKER and input_message.get("check"):
                 logger.error("Checker is disabled in settings - see ENABLE_CHECKER value.")
 
             collection, upgraded_collection, compiled_collection = create_collections(

--- a/process/views/api.py
+++ b/process/views/api.py
@@ -27,6 +27,9 @@ def create_collection(request):
             )
 
         try:
+            if not settings.ENABLE_CHECKER and input_message.get("check", False):
+                logger.error("Checker is disabled in settings - see ENABLE_CHECKER value.")
+
             collection, upgraded_collection, compiled_collection = create_collections(
                 input_message["source_id"],
                 input_message["data_version"],


### PR DESCRIPTION
Hi James,
well, this looked easy, but was a tough one:( I've tested multiple collections, but strongly suggest to test a bit harder - I\m limited with time here. 

- new variable ENABLE_CHECKER was introduced to the code
- checker ends itself with an error message if started in env with checker disabled
- I suggest to consider behaviour in process/views/api.py - it logs an error, if checker is disabled. But does not crash - I've chosen this approach instead of direct crash. As the crash will require changes in collect (and I didn't wanted to force you to implement those) Once clear, the loader should be updated to behave in the same way.
