### PR TITLE
fix: Skip obsolete message on collection foreign-key violation

### DIFF
--- a/process/management/commands/record_compiler.py
+++ b/process/management/commands/record_compiler.py
@@ -33,8 +33,9 @@ def callback(client_state, channel, method, properties, input_message):
     ocid = input_message["ocid"]
     compiled_collection_id = input_message["compiled_collection_id"]
 
-    compiled_collection = Collection.objects.get(pk=compiled_collection_id)
-    if compiled_collection.deleted_at:
+    # The compiled collection can be deleted (canceled, or hard-deleted by the wiper) while its messages are queued.
+    compiled_collection = Collection.objects.filter(pk=compiled_collection_id).first()
+    if compiled_collection is None or compiled_collection.deleted_at:
         ack(client_state, channel, method.delivery_tag)
         return
 

--- a/process/management/commands/release_compiler.py
+++ b/process/management/commands/release_compiler.py
@@ -28,8 +28,9 @@ def callback(client_state, channel, method, properties, input_message):
     ocids = input_message["ocids"]
     compiled_collection_id = input_message["compiled_collection_id"]
 
-    compiled_collection = Collection.objects.get(pk=compiled_collection_id)
-    if compiled_collection.deleted_at:
+    # The compiled collection can be deleted (canceled, or hard-deleted by the wiper) while its messages are queued.
+    compiled_collection = Collection.objects.filter(pk=compiled_collection_id).first()
+    if compiled_collection is None or compiled_collection.deleted_at:
         ack(client_state, channel, method.delivery_tag)
         return
 

--- a/process/util.py
+++ b/process/util.py
@@ -64,11 +64,20 @@ def decorator(decode, callback, state, channel, method, properties, body):
     """
 
     def errback(exception):
-        # A foreign-key violation can occur when a package_data or data row is still referenced (e.g. by another
+        # A foreign-key violation on a collection reference occurs when a collection is deleted (by the wiper) while
+        # another worker is compiling releases into it or storing files for it: the concurrent transaction commits
+        # rows referencing the now-deleted collection, so the foreign key fails at COMMIT. The message is obsolete, so
+        # skip it, like Collection.DoesNotExist below. (The constraint name is locale-independent, unlike the detail.)
+        #
+        # Any other foreign-key violation means a package_data or data row is still referenced (e.g. by another
         # collection's release), which indicates an error in logic or configuration (e.g. toggling DEDUPLICATE_DATA).
         if isinstance(exception, IntegrityError) and isinstance(exception.__cause__, errors.ForeignKeyViolation):
-            logger.exception("Unhandled exception when consuming %r, shutting down gracefully", body)
-            add_callback_threadsafe(state.connection, state.interrupt)
+            if "collection_id" in (exception.__cause__.diag.constraint_name or ""):
+                logger.exception("Collection deleted while consuming %r, skipping", body)
+                nack(state, channel, method.delivery_tag, requeue=False)
+            else:
+                logger.exception("Unhandled exception when consuming %r, shutting down gracefully", body)
+                add_callback_threadsafe(state.connection, state.interrupt)
         # A deadlock can occur when concurrent transactions INSERT or DELETE the same rows in a different order.
         # Requeue the message to retry it. The callback must leave no partial state on a rolled-back transaction
         # (see e.g. file_worker and wiper). Sleep first, so that the transaction that won the deadlock can commit,

--- a/tests/commands/test_record_compiler.py
+++ b/tests/commands/test_record_compiler.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+from process.management.commands.record_compiler import callback
+from process.models import Collection
+
+
+class RecordCompilerCallbackTests(TransactionTestCase):
+    def setUp(self):
+        self.parent = Collection.objects.create(
+            source_id="test_record_package",
+            data_version="2023-01-01T00:00:00Z",
+            data_type={"format": "record package", "array": False, "concatenated": False},
+            store_end_at=timezone.now(),
+            steps=["compile"],
+        )
+        self.compiled = Collection.objects.create(
+            source_id="test_record_package",
+            data_version="2023-01-01T00:00:00Z",
+            parent=self.parent,
+            transform_type=Collection.Transform.COMPILE_RELEASES,
+            compilation_started=True,
+        )
+
+    def _callback(self, client_state, channel, compiled_collection_id):
+        method = MagicMock(delivery_tag=1)
+        message = {"collection_id": self.parent.pk, "compiled_collection_id": compiled_collection_id, "ocid": "a"}
+        callback(client_state, channel, method, MagicMock(), message)
+
+    @patch("process.management.commands.record_compiler.publish")
+    @patch("process.management.commands.record_compiler.ack")
+    def test_acks_when_collection_missing(self, ack, publish):
+        # The compiled collection was hard-deleted (e.g. by the wiper) while its messages were queued.
+        client_state, channel = MagicMock(), MagicMock()
+
+        self._callback(client_state, channel, self.compiled.pk + 1000)
+
+        ack.assert_called_once_with(client_state, channel, 1)
+        publish.assert_not_called()
+
+    @patch("process.management.commands.record_compiler.publish")
+    @patch("process.management.commands.record_compiler.ack")
+    def test_acks_when_collection_deleted(self, ack, publish):
+        self.compiled.deleted_at = timezone.now()
+        self.compiled.save()
+        client_state, channel = MagicMock(), MagicMock()
+
+        self._callback(client_state, channel, self.compiled.pk)
+
+        ack.assert_called_once_with(client_state, channel, 1)
+        publish.assert_not_called()

--- a/tests/commands/test_release_compiler.py
+++ b/tests/commands/test_release_compiler.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+from process.management.commands.release_compiler import callback
+from process.models import Collection
+
+
+class ReleaseCompilerCallbackTests(TransactionTestCase):
+    def setUp(self):
+        self.parent = Collection.objects.create(
+            source_id="test_release_package",
+            data_version="2023-01-01T00:00:00Z",
+            data_type={"format": "release package", "array": False, "concatenated": False},
+            store_end_at=timezone.now(),
+            steps=["compile"],
+        )
+        self.compiled = Collection.objects.create(
+            source_id="test_release_package",
+            data_version="2023-01-01T00:00:00Z",
+            parent=self.parent,
+            transform_type=Collection.Transform.COMPILE_RELEASES,
+            compilation_started=True,
+        )
+
+    def _callback(self, client_state, channel, compiled_collection_id):
+        method = MagicMock(delivery_tag=1)
+        message = {"collection_id": self.parent.pk, "compiled_collection_id": compiled_collection_id, "ocids": ["a"]}
+        callback(client_state, channel, method, MagicMock(), message)
+
+    @patch("process.management.commands.release_compiler.publish")
+    @patch("process.management.commands.release_compiler.ack")
+    def test_acks_when_collection_missing(self, ack, publish):
+        # The compiled collection was hard-deleted (e.g. by the wiper) while its messages were queued.
+        client_state, channel = MagicMock(), MagicMock()
+
+        self._callback(client_state, channel, self.compiled.pk + 1000)
+
+        ack.assert_called_once_with(client_state, channel, 1)
+        publish.assert_not_called()
+
+    @patch("process.management.commands.release_compiler.publish")
+    @patch("process.management.commands.release_compiler.ack")
+    def test_acks_when_collection_deleted(self, ack, publish):
+        self.compiled.deleted_at = timezone.now()
+        self.compiled.save()
+        client_state, channel = MagicMock(), MagicMock()
+
+        self._callback(client_state, channel, self.compiled.pk)
+
+        ack.assert_called_once_with(client_state, channel, 1)
+        publish.assert_not_called()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import json
 from collections import OrderedDict
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 from django.db import IntegrityError, OperationalError
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -51,14 +51,31 @@ class ErrbackTests(SimpleTestCase):
 
     @patch("process.util.nack")
     @patch("process.util.add_callback_threadsafe")
-    def test_foreign_key_violation_shuts_down(self, add_callback_threadsafe, nack):
+    def test_data_foreign_key_violation_shuts_down(self, add_callback_threadsafe, nack):
+        cause = errors.ForeignKeyViolation("still referenced")
         exception = IntegrityError("still referenced")
-        exception.__cause__ = errors.ForeignKeyViolation("still referenced")
+        exception.__cause__ = cause
 
-        state, _, _ = self.run_errback(exception)
+        diag = Mock(constraint_name="compiled_release_data_id_1a2b3c4d_fk")
+        with patch.object(type(cause), "diag", new_callable=PropertyMock, return_value=diag):
+            state, _, _ = self.run_errback(exception)
 
         add_callback_threadsafe.assert_called_once_with(state.connection, state.interrupt)
         nack.assert_not_called()
+
+    @patch("process.util.nack")
+    @patch("process.util.add_callback_threadsafe")
+    def test_collection_foreign_key_violation_skips(self, add_callback_threadsafe, nack):
+        cause = errors.ForeignKeyViolation("collection deleted")
+        exception = IntegrityError("collection deleted")
+        exception.__cause__ = cause
+
+        diag = Mock(constraint_name="collection_note_collection_id_b446d931_fk")
+        with patch.object(type(cause), "diag", new_callable=PropertyMock, return_value=diag):
+            state, channel, method = self.run_errback(exception)
+
+        add_callback_threadsafe.assert_not_called()
+        nack.assert_called_once_with(state, channel, method.delivery_tag, requeue=False)
 
     @patch("process.util.time.sleep")
     @patch("process.util.nack")


### PR DESCRIPTION
A collection can be deleted (by the wiper) while another worker is
compiling releases into it or storing files for it. The concurrent
transaction commits rows referencing the now-deleted collection, so the
foreign key fails at COMMIT. This is a benign race, not a logic error:
the message is obsolete, so skip it (like Collection.DoesNotExist),
rather than shutting the worker down.

Distinguish this case from other foreign-key violations (a package_data
or data row still referenced), which continue to shut down, by the
collection_id in the violated constraint name.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WYEutYV3RKbyi8Vd26QdxE